### PR TITLE
Update doc

### DIFF
--- a/doc/blog/2024-08-07-hello/index.md
+++ b/doc/blog/2024-08-07-hello/index.md
@@ -6,3 +6,5 @@ tags: [hello]
 ---
 
 Hello! I've just launched a blog section within the cmdlang documentation, powered by Docusaurus. This new space is designed to keep you updated with all things related to cmdlang. Stay tuned for more updates and insights. Happy reading!
+
+<!-- truncate -->

--- a/doc/blog/2024-09-07-yet-another-cli/index.md
+++ b/doc/blog/2024-09-07-yet-another-cli/index.md
@@ -13,6 +13,8 @@ I hope you had a nice summer! Mine took an unexpected turn when, roughly at the 
 
 When I read climate's [terminology](https://github.com/gridbugs/climate?tab=readme-ov-file#terminology) section and how it defines `Terms`, `Arguments`, and `Parameters`, something clicked. Seeing how `climate`'s API managed to make positional and named arguments fit so nicely together, I thought: "Wow, for the first time, it seems I'll be able to write a CLI spec on a whiteboard without referring to some code I never seem to get right (I am looking at you, core.command's anonymous arguments)."
 
+<!-- truncate -->
+
 I got quite excited and thought: "Can I switch to `climate` today?" But reality checked: it's not on opam yet, still under construction, I'm not sure what the community will do, etc.
 
 Implementing my own engine for an API resembling `climate` felt like a wasted effort, knowing about the work happening in `climate`. Still, having a `'a Param.t`, `'a Arg.t`, and `'a Command.t` type that I would get to know and love felt too good to pass up.

--- a/doc/docs/reference/odoc.md
+++ b/doc/docs/reference/odoc.md
@@ -1,3 +1,33 @@
 # OCaml Packages Documentation
 
 You can view the published odoc pages here: [https://mbarbin.github.io/cmdlang/odoc/](https://mbarbin.github.io/cmdlang/odoc/).
+
+## Release status
+
+### Pending releases
+
+We plan to release the following packages soon to allow interested parties to experiment with cmdlang and provide early feedback.
+
+| package              | released to opam |
+|----------------------|:----------------:|
+| cmdlang.opam         |   pending        |
+| cmdlang-to-cmdliner  |   pending        |
+| cmdlang-to-climate   |   pending        |
+
+### Planned releases
+
+| package              | released to opam |
+|----------------------|:----------------:|
+| cmdlang-to-base      |   planned        |
+
+We also plan to release the translation to `core.command`. However, this will require additional work. Specifically, we aim to complete the coverage of that part of the code and exercise the translation using special configuration options in a tutorial.
+
+### To be determined
+
+| package                   | released to opam |
+|---------------------------|:----------------:|
+| err                       |   TBD            |
+| err-cli                   |   TBD            |
+| cmdlang-cmdliner-runner   |   TBD            |
+
+These packages are more experimental and opinionated in nature. They will require further consideration and potential redesign before being released.

--- a/doc/docs/tutorials/getting-started/README.md
+++ b/doc/docs/tutorials/getting-started/README.md
@@ -81,7 +81,7 @@ As you'll learn, `cmdlang` doesn't come with its own command runner. Instead, it
 
 <!-- $MDX skip -->
 ```sh
-$ opam install cmdlang-cmdliner-runner
+$ opam install cmdlang-to-cmdliner cmdliner
 ```
 
 **Setup bin/dune**
@@ -90,7 +90,7 @@ $ opam install cmdlang-cmdliner-runner
 ```lisp
 (executable
  (name main)
- (libraries cmdlang_cmdliner_runner getting_started))
+ (libraries cmdlang-to-cmdliner cmdliner getting_started))
 ```
 
 An invocation of `cmdliner` for a `cmdlang` command may look like this:
@@ -98,10 +98,12 @@ An invocation of `cmdliner` for a `cmdlang` command may look like this:
 <!-- $MDX file=main.ml -->
 ```ocaml
 let () =
-  Cmdlang_cmdliner_runner.run
-    Getting_started.cmd
-    ~name:"my-calculator"
-    ~version:"%%VERSION%%"
+  Cmdliner.Cmd.eval
+    (Cmdlang_to_cmdliner.Translate.command
+       Getting_started.cmd
+       ~name:"my-calculator"
+       ~version:"%%VERSION%%")
+  |> Stdlib.exit
 ;;
 ```
 
@@ -324,7 +326,7 @@ Try 'my-calculator --help' for more information.
 
 ## Conclusion
 
-In this tutorial, we've created a command-line interface and exposed its entry point from a library. Then, we've used the `cmdlang_to_cmdliner` translation step and set up dune build rules to create an executable that runs this command with `cmdliner` as a backend.
+In this tutorial, we've created a command-line interface and exposed its entry point from a library. Then, we've used the `cmdlang-to-cmdliner` translation step and set up dune build rules to create an executable that runs this command with `cmdliner` as a backend.
 
 While we've covered the basics, there are additional features you might want to explore, such as generating complete man pages and setting up auto-completion. We'll cover these advanced topics in other parts of the documentation.
 

--- a/doc/docs/tutorials/getting-started/bin/dune
+++ b/doc/docs/tutorials/getting-started/bin/dune
@@ -1,6 +1,6 @@
 (executable
  (name main)
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a)
- (libraries cmdlang_cmdliner_runner getting_started)
+ (libraries cmdlang-to-cmdliner cmdliner getting_started)
  (instrumentation
   (backend bisect_ppx)))

--- a/doc/docs/tutorials/getting-started/bin/main.ml
+++ b/doc/docs/tutorials/getting-started/bin/main.ml
@@ -1,6 +1,8 @@
 let () =
-  Cmdlang_cmdliner_runner.run
-    Getting_started.cmd
-    ~name:"my-calculator"
-    ~version:"%%VERSION%%"
+  Cmdliner.Cmd.eval
+    (Cmdlang_to_cmdliner.Translate.command
+       Getting_started.cmd
+       ~name:"my-calculator"
+       ~version:"%%VERSION%%")
+  |> Stdlib.exit
 ;;


### PR DESCRIPTION
- Add reference notice on release plans in the doc
- Adding blog truncate markers (warning during docusaurus build)
- Update tutorial to use cmdlang-to-cmdliner (the other package is not planned for a release at this time)