### PR TITLE
Prepare release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,11 @@
-## 0.0.6 (unreleased)
-
-### Added
+## 0.0.6 (2024-10-24)
 
 ### Changed
 
-### Deprecated
-
-### Fixed
-
-### Removed
+- Prepare documentation for initial release.
+- Upgrade to `climate.0.1.0`.
+- Make opam files pass opam-repository linting rules.
+- Upgrade Docusaurus.
 
 ## 0.0.5 (2024-09-17)
 

--- a/cmdlang-cmdliner-runner.opam
+++ b/cmdlang-cmdliner-runner.opam
@@ -9,10 +9,10 @@ doc: "https://mbarbin.github.io/cmdlang/"
 bug-reports: "https://github.com/mbarbin/cmdlang/issues"
 depends: [
   "dune" {>= "3.16"}
-  "ocaml" {>= "5.2"}
+  "ocaml" {>= "4.14"}
   "cmdlang" {= version}
   "cmdlang-to-cmdliner" {= version}
-  "cmdliner" {= "1.3.0"}
+  "cmdliner" {>= "1.3.0" & < "1.4"}
   "err" {= version}
   "odoc" {with-doc}
 ]

--- a/cmdlang-tests.opam
+++ b/cmdlang-tests.opam
@@ -13,13 +13,13 @@ depends: [
   "ocamlformat" {with-dev-setup & = "0.26.2"}
   "base" {>= "v0.17" & < "v0.18"}
   "bisect_ppx" {with-dev-setup & >= "2.8.3"}
-  "climate" {>= "0.1.0~preview-0.1"}
+  "climate" {>= "0.1.0~" & < "0.2"}
   "cmdlang" {= version}
   "cmdlang-cmdliner-runner" {= version}
   "cmdlang-to-base" {= version}
   "cmdlang-to-climate" {= version}
   "cmdlang-to-cmdliner" {= version}
-  "cmdliner" {= "1.3.0"}
+  "cmdliner" {>= "1.3.0"}
   "core" {>= "v0.17" & < "v0.18"}
   "core_unix" {>= "v0.17" & < "v0.18"}
   "err" {= version}

--- a/cmdlang-to-climate.opam
+++ b/cmdlang-to-climate.opam
@@ -9,8 +9,8 @@ doc: "https://mbarbin.github.io/cmdlang/"
 bug-reports: "https://github.com/mbarbin/cmdlang/issues"
 depends: [
   "dune" {>= "3.16"}
-  "ocaml" {>= "5.2"}
-  "climate" {>= "0.1.0~preview-0.1"}
+  "ocaml" {>= "4.14"}
+  "climate" {>= "0.1.0~" & < "0.2"}
   "cmdlang" {= version}
   "odoc" {with-doc}
 ]

--- a/cmdlang-to-cmdliner.opam
+++ b/cmdlang-to-cmdliner.opam
@@ -9,9 +9,9 @@ doc: "https://mbarbin.github.io/cmdlang/"
 bug-reports: "https://github.com/mbarbin/cmdlang/issues"
 depends: [
   "dune" {>= "3.16"}
-  "ocaml" {>= "5.2"}
+  "ocaml" {>= "4.14"}
   "cmdlang" {= version}
-  "cmdliner" {= "1.3.0"}
+  "cmdliner" {>= "1.3.0" & < "1.4"}
   "odoc" {with-doc}
 ]
 build: [

--- a/cmdlang.opam
+++ b/cmdlang.opam
@@ -9,7 +9,7 @@ doc: "https://mbarbin.github.io/cmdlang/"
 bug-reports: "https://github.com/mbarbin/cmdlang/issues"
 depends: [
   "dune" {>= "3.16"}
-  "ocaml" {>= "5.2"}
+  "ocaml" {>= "4.14"}
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,7 @@
  (synopsis "Declarative Command-line Parsing for OCaml")
  (depends
   (ocaml
-   (>= 5.2))))
+   (>= 4.14))))
 
 (package
  (name err)
@@ -121,20 +121,24 @@
  (synopsis "Convert cmdlang Parsers to cmdliner")
  (depends
   (ocaml
-   (>= 5.2))
+   (>= 4.14))
   (cmdlang
    (= :version))
   (cmdliner
-   (= 1.3.0))))
+   (and
+    (>= 1.3.0)
+    (< 1.4)))))
 
 (package
  (name cmdlang-to-climate)
  (synopsis "Convert cmdlang Parsers to climate")
  (depends
   (ocaml
-   (>= 5.2))
+   (>= 4.14))
   (climate
-   (>= 0.1.0~preview-0.1))
+   (and
+    (>= 0.1.0~)
+    (< 0.2)))
   (cmdlang
    (= :version))))
 
@@ -143,13 +147,15 @@
  (synopsis "A cmdlang runner using cmdliner and err")
  (depends
   (ocaml
-   (>= 5.2))
+   (>= 4.14))
   (cmdlang
    (= :version))
   (cmdlang-to-cmdliner
    (= :version))
   (cmdliner
-   (= 1.3.0))
+   (and
+    (>= 1.3.0)
+    (< 1.4)))
   (err
    (= :version))))
 
@@ -172,7 +178,9 @@
     :with-dev-setup
     (>= 2.8.3)))
   (climate
-   (>= 0.1.0~preview-0.1))
+   (and
+    (>= 0.1.0~)
+    (< 0.2)))
   (cmdlang
    (= :version))
   (cmdlang-cmdliner-runner
@@ -184,7 +192,7 @@
   (cmdlang-to-cmdliner
    (= :version))
   (cmdliner
-   (= 1.3.0))
+   (>= 1.3.0))
   (core
    (and
     (>= v0.17)

--- a/lib/cmdlang_ast/src/ast.mli
+++ b/lib/cmdlang_ast/src/ast.mli
@@ -1,3 +1,20 @@
+(** The internal representation for the EDSL used by the cmdlang library.
+
+    Cmdlang doesn't include an execution engine. Instead, Cmdlang parsers are
+    automatically translated to `cmdliner`, `core.command`, or `climate`
+    commands for execution.
+
+    When you use the cmdlang library to define a command-line interface, you are
+    effectively building a value of type [Cmdlang_ast.Ast.Command.t]. It is then
+    converted internally to the targeted backend.
+
+    This module is not meant to be used directly by users of the library.
+    Rather, users use the [Cmdlang.Command] interface which provides a
+    high-level API meant to be ergonomic and user-friendly.
+
+    [Cmdlang_ast] is exposed to allow extending the library with new backends or
+    to write analysis tools, etc. *)
+
 type 'a parse := string -> ('a, [ `Msg of string ]) result
 type 'a print := Format.formatter -> 'a -> unit
 

--- a/lib/cmdlang_cmdliner_runner/src/cmdlang_cmdliner_runner.mli
+++ b/lib/cmdlang_cmdliner_runner/src/cmdlang_cmdliner_runner.mli
@@ -1,5 +1,13 @@
-(** This is the standard way that is designed with cmdlang, assuming you are
-    using [Err] etc. *)
+(** An opinionated runner for cmdlang parsers using cmdliner as a backend.
+
+    This module provides a default runner that wraps [cmdlang-to-cmdliner] and
+    runs the command under a [Err.protect] block.
+
+    This furnishes a standard way to run cmdlang commands, assuming you are
+    using [Err].
+
+    It is opinionated and adds a few dependencies to your project, such as
+    [Logs] and [Fmt]. *)
 val run
   :  ?exn_handler:(exn -> Err.t option)
   -> unit Cmdlang.Command.t

--- a/lib/cmdlang_to_base/src/translate.mli
+++ b/lib/cmdlang_to_base/src/translate.mli
@@ -1,3 +1,15 @@
+(** Translate cmdlang parsers to core.command. *)
+
+(** {1 Configuration}
+
+    The translation implemented in this module allows some configuration
+    regarding the resulting command that you want to build. The goal of this
+    configuration is to furnish assistance for complex multi-stages migrations from
+    a backend to another.
+
+    It is currently experimental, not well tested or documented, and expected to
+    change in the future. *)
+
 module Config : sig
   type t
 

--- a/lib/cmdlang_to_climate/src/translate.mli
+++ b/lib/cmdlang_to_climate/src/translate.mli
@@ -1,3 +1,11 @@
+(** Translate cmdlang parsers to climate.
+
+    The translation to climate is experimental, not well tested or documented,
+    and doesn't support all features of climate. In particular there's currently
+    no support to target the auto-completion features offered by climate. This
+    is an area left for future work. More info
+    {{:https://mbarbin.github.io/cmdlang/docs/explanation/future_plans/} here}. *)
+
 (** {1 Param} *)
 
 val param : 'a Cmdlang.Command.Param.t -> 'a Climate.Arg_parser.conv

--- a/lib/cmdlang_to_cmdliner/src/translate.mli
+++ b/lib/cmdlang_to_cmdliner/src/translate.mli
@@ -1,3 +1,5 @@
+(** Translate cmdlang parsers to cmdliner. *)
+
 (** {1 Param} *)
 
 val param : 'a Cmdlang.Command.Param.t -> 'a Cmdliner.Arg.conv


### PR DESCRIPTION
### Changed

- Prepare documentation for initial release.
- Upgrade to `climate.0.1.0`.
- Make opam files pass opam-repository linting rules.
- Upgrade Docusaurus.