### PR TITLE
Upgrade to climate.0.3.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,8 @@
         "cmdlang",
         "cmdliner",
         "conv",
+        "docv",
+        "Fpath",
         "groff",
         "janestreet",
         "odoc",

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Fix trailing dot additions in `to-cmdliner` for cases such as `?.` and `..` (#PR, @mbarbin).
+
 ### Removed
 
 ## 0.0.8 (2024-11-14)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Document presence in stdlib-runner help (required, default, etc.) (#PR, @mbarbin).
+- Minor refactor in stdlib-runner (#PR, @mbarbin).
 - Upgrade to `climate.0.3.0` (#PR, @mbarbin).
 
 ### Deprecated

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,15 +4,15 @@
 
 ### Changed
 
-- Document presence in stdlib-runner help (required, default, etc.) (#PR, @mbarbin).
-- Minor refactor in stdlib-runner (#PR, @mbarbin).
-- Upgrade to `climate.0.3.0` (#PR, @mbarbin).
+- Document presence in stdlib-runner help (required, default, etc.) (#19, @mbarbin).
+- Minor refactor in stdlib-runner (#19, @mbarbin).
+- Upgrade to `climate.0.3.0` (#19, @mbarbin).
 
 ### Deprecated
 
 ### Fixed
 
-- Fix trailing dot additions in `to-cmdliner` for cases such as `?.` and `..` (#PR, @mbarbin).
+- Fix trailing dot additions in `to-cmdliner` for cases such as `?.` and `..` (#19, @mbarbin).
 
 ### Removed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,17 @@
+## 0.0.9 (unreleased)
+
+### Added
+
+### Changed
+
+- Upgrade to `climate.0.3.0` (#PR, @mbarbin).
+
+### Deprecated
+
+### Fixed
+
+### Removed
+
 ## 0.0.8 (2024-11-14)
 
 ### Added

--- a/cmdlang-tests.opam
+++ b/cmdlang-tests.opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlformat" {with-dev-setup & = "0.26.2"}
   "base" {>= "v0.17" & < "v0.18"}
   "bisect_ppx" {with-dev-setup & >= "2.8.3"}
-  "climate" {>= "0.1.0~" & < "0.2"}
+  "climate" {>= "0.3.0"}
   "cmdlang" {= version}
   "cmdlang-stdlib-runner" {= version}
   "cmdlang-to-base" {= version}

--- a/cmdlang-to-climate.opam
+++ b/cmdlang-to-climate.opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/mbarbin/cmdlang/issues"
 depends: [
   "dune" {>= "3.16"}
   "ocaml" {>= "4.14"}
-  "climate" {>= "0.1.0"}
+  "climate" {>= "0.3.0"}
   "cmdlang" {= version}
   "odoc" {with-doc}
 ]

--- a/doc/docs/reference/odoc.md
+++ b/doc/docs/reference/odoc.md
@@ -4,20 +4,13 @@ You can view the published odoc pages here: [https://mbarbin.github.io/cmdlang/o
 
 ## Release status
 
-### Pending releases
+We have released an initial set of packages to allow interested parties to experiment with cmdlang and provide early feedback.
 
-We have released the following packages to allow interested parties to experiment with cmdlang and provide early feedback.
+We plan to release the translation to `core.command` next. However, this will require additional work. Specifically, we aim to complete the coverage of that part of the code and exercise the translation using special configuration options in a tutorial.
 
 | package              | released to opam |
 |----------------------|:----------------:|
 | cmdlang.opam         |   ✓              |
 | cmdlang-to-cmdliner  |   ✓              |
 | cmdlang-to-climate   |   ✓              |
-
-### Planned releases
-
-We also plan to release the translation to `core.command`. However, this will require additional work. Specifically, we aim to complete the coverage of that part of the code and exercise the translation using special configuration options in a tutorial.
-
-| package              | released to opam |
-|----------------------|:----------------:|
 | cmdlang-to-base      |   planned        |

--- a/doc/docs/reference/odoc.md
+++ b/doc/docs/reference/odoc.md
@@ -6,18 +6,18 @@ You can view the published odoc pages here: [https://mbarbin.github.io/cmdlang/o
 
 ### Pending releases
 
-We plan to release the following packages soon to allow interested parties to experiment with cmdlang and provide early feedback.
+We have released the following packages to allow interested parties to experiment with cmdlang and provide early feedback.
 
 | package              | released to opam |
 |----------------------|:----------------:|
-| cmdlang.opam         |   pending        |
-| cmdlang-to-cmdliner  |   pending        |
-| cmdlang-to-climate   |   pending        |
+| cmdlang.opam         |   ✓              |
+| cmdlang-to-cmdliner  |   ✓              |
+| cmdlang-to-climate   |   ✓              |
 
 ### Planned releases
+
+We also plan to release the translation to `core.command`. However, this will require additional work. Specifically, we aim to complete the coverage of that part of the code and exercise the translation using special configuration options in a tutorial.
 
 | package              | released to opam |
 |----------------------|:----------------:|
 | cmdlang-to-base      |   planned        |
-
-We also plan to release the translation to `core.command`. However, this will require additional work. Specifically, we aim to complete the coverage of that part of the code and exercise the translation using special configuration options in a tutorial.

--- a/dune-project
+++ b/dune-project
@@ -97,7 +97,7 @@
    (>= 4.14))
   (climate
    (and
-    (>= 0.1.0)))
+    (>= 0.3.0)))
   (cmdlang
    (= :version))))
 
@@ -130,8 +130,7 @@
     (>= 2.8.3)))
   (climate
    (and
-    (>= 0.1.0~)
-    (< 0.2)))
+    (>= 0.3.0)))
   (cmdlang
    (= :version))
   (cmdlang-stdlib-runner

--- a/lib/cmdlang/src/command.mli
+++ b/lib/cmdlang/src/command.mli
@@ -24,6 +24,72 @@
     {{:https://mbarbin.github.io/cmdlang/docs/tutorials/getting-started/} tutorial}
     from cmdlang's documentation. *)
 
+(** {1 Terminology}
+
+    The terminology used by cmdlang is inspired by
+    {{:https://github.com/gridbugs/climate/} climate}.
+
+    {2:arguments Arguments}
+
+    An {e Argument} is a distinct piece of information passed to the program on
+    the command line. For example, in the command [make -td --jobs 4 all], there
+    are 4 arguments: [-t], [-d], [--jobs 4], and [all]. Arguments are declared
+    using the module {!module:Arg}.
+
+    Arguments can be either {e positional} or {e named}:
+
+    {3:positional_arguments Positional arguments}
+
+    {e Positional} arguments are identified by their position (0-based) in the
+    argument list rather than by name.
+
+    {3:named_arguments Named arguments}
+
+    {e Named} arguments can be either {e short} or {e long}:
+    - {e Short} named arguments begin with a single [-] followed by a single
+      non [-] character, such as [-l].
+    - {e Long} named arguments begin with [--] followed by several non [-]
+      characters, such as [--jobs].
+
+    {3:parameters Parameters}
+
+    A {e Parameter} is a single value that is attached to a named argument on
+    the command line. For example, in [make --jobs 4], ["jobs"] is the argument
+    name and [4] is its parameter. Parameters are declared using the module
+    {!module:Param}.
+
+    {2:docv docv}
+
+    The term {e docv} is a convention in the API to denote the string that will
+    be printed in the help messages in place of the value that is actually
+    expected. This applies to both positional arguments and parameters of named
+    arguments. For example, in the help message for a named argument, you might
+    see [--flag VALUE], where "VALUE" is the {e docv} representing the expected
+    parameter. Similarly, for positional arguments, you might see usage like
+    [./main.exe VAL VAL], where "VAL" is the {e docv} representing the expected
+    positional argument. The name {e docv} stands for "documentation value" and
+    was inspired by {i cmdliner}.
+
+    {2 Supported Command Line Syntax}
+
+    Not all syntaxes are supported by all backends, so you should check the
+    documentation of the targeted backend for more information, and choose your
+    execution engine according to your preferences.
+
+    For example, some backends may support combining a collection of short named
+    arguments together with a single leading [-] followed by each short argument
+    name (in which case [ls -la] is an alternative way of writing [ls -l -a]).
+
+    As another example, we list here the different ways supported by climate of
+    passing a parameter to a named argument on the command line:
+
+    {v
+      make --jobs=4   (* long name with equals sign *)
+      make --jobs 4   (* long name space delimited *)
+      make -j 4       (* short name space delimited *)
+      make -j4        (* short name without space *)
+    v} *)
+
 (** {1 Utils} *)
 
 module Nonempty_list : sig
@@ -104,16 +170,31 @@ module type Validated_string = sig
   val to_string : t -> string
 end
 
-(** {1 Parameters} *)
+(** {1 Building Parameters} *)
 
 module Param : sig
-  type 'a t
+  (** Refer to the {{!parameters} Parameters} terminology. *)
+
+  (** Parsing parameters of type ['a] from the command line. *)
   type 'a parse := string -> ('a, [ `Msg of string ]) result
+
+  (** Printing parameters of type ['a] back to their expected command line
+      syntax. Printing parameter is used for example when documenting default
+      values in the help messages. *)
   type 'a print := Format.formatter -> 'a -> unit
+
+  (** A type to hold the capability of parsing and printing a parameter of
+      type ['a]. *)
+  type 'a t
 
   val create : docv:string -> parse:'a parse -> print:'a print -> 'a t
 
   (** {1 Basic types} *)
+
+  (** The API supports basic types with default {!docv} values. These defaults
+      can be overridden for each argument. The default {e docv} is used only
+      if none is specified at the argument level. The actual syntax used by
+      default depend on the targeted backend. *)
 
   val string : string t
   val int : int t
@@ -123,20 +204,52 @@ module Param : sig
 
   (** {1 Helpers} *)
 
+  (** Helpers for creating parameters for custom types. These helpers also come
+      with default {e docv} values, which can be overridden as needed. *)
+
+  (** Create a parameter for an enumerated type. The module must implement the
+      [Enumerated_stringable] interface.
+
+      Example:
+      {[
+        module Color = struct
+          type t =
+            | Red
+            | Green
+            | Blue
+
+          let all = [ Red; Green; Blue ]
+
+          let to_string = function
+            | Red -> "red"
+            | Green -> "green"
+            | Blue -> "blue"
+          ;;
+        end
+
+        let color_param = Param.enumerated ~docv:"COLOR" (module Color)
+      ]}
+
+      The usage message will show the supported values for [COLOR]. *)
   val enumerated : ?docv:string -> (module Enumerated_stringable with type t = 'a) -> 'a t
+
   val stringable : ?docv:string -> (module Stringable with type t = 'a) -> 'a t
 
+  (** To be used with custom types when the parsing may fail. *)
   val validated_string
     :  ?docv:string
     -> (module Validated_string with type t = 'a)
     -> 'a t
 
+  (** Parser for a list of values separated by commas. *)
   val comma_separated : 'a t -> 'a list t
 end
 
-(** {1 Arguments} *)
+(** {1 Building Arguments} *)
 
 module Arg : sig
+  (** Refer to the {{!arguments} Arguments} terminology. *)
+
   type 'a t
 
   (** {1 Applicative operations} *)
@@ -148,10 +261,17 @@ module Arg : sig
 
   (** {1 Named arguments} *)
 
+  (** A flag that may appear at most once on the command line. *)
   val flag : string Nonempty_list.t -> doc:string -> bool t
+
+  (** A flag that may appear multiple times on the command line. Evaluates to
+      the number of times the flag appeared. *)
   val flag_count : string Nonempty_list.t -> doc:string -> int t
+
+  (** A required named argument (must appear exactly once on the command line). *)
   val named : ?docv:string -> string Nonempty_list.t -> 'a Param.t -> doc:string -> 'a t
 
+  (** A named argument that may appear multiple times on the command line. *)
   val named_multi
     :  ?docv:string
     -> string Nonempty_list.t
@@ -159,6 +279,7 @@ module Arg : sig
     -> doc:string
     -> 'a list t
 
+  (** An optional named argument (may appear at most once). *)
   val named_opt
     :  ?docv:string
     -> string Nonempty_list.t
@@ -166,6 +287,7 @@ module Arg : sig
     -> doc:string
     -> 'a option t
 
+  (** An optional named argument with a default value. *)
   val named_with_default
     :  ?docv:string
     -> string Nonempty_list.t
@@ -178,9 +300,16 @@ module Arg : sig
 
   (** Positional argument start at index 0. *)
 
+  (** A required positional argument. It must appear exactly once at position
+      [i] on the command line. *)
   val pos : ?docv:string -> pos:int -> 'a Param.t -> doc:string -> 'a t
+
+  (** An optional positional argument at position [i]. Optional positional
+      argument must not be followed by more positional argument as this
+      creates ambiguous specifications. *)
   val pos_opt : ?docv:string -> pos:int -> 'a Param.t -> doc:string -> 'a option t
 
+  (** A optional positional argument with a default value. *)
   val pos_with_default
     :  ?docv:string
     -> pos:int
@@ -189,15 +318,58 @@ module Arg : sig
     -> doc:string
     -> 'a t
 
+  (** Return the list of all remaining positional arguments. *)
   val pos_all : ?docv:string -> 'a Param.t -> doc:string -> 'a list t
 end
 
-(** {1 Commands} *)
+(** {1 Building Commands} *)
 
 type 'a t
 
+(** Create a command with the given argument specification and summary.
+
+    - [readme] is an optional function that returns a detailed description of
+      the command.
+    - [summary] is a short description of what the command does.
+    - The argument specification is provided by an ['a Arg.t].
+
+    Example:
+    {[
+      let hello_cmd =
+        Command.make
+          ~summary:"Prints 'Hello, world!'"
+          ~readme:(fun () ->
+            {|
+      This would usually be a longer description of the command.
+      It can be written on multiple lines.
+      |})
+          (let open Command.Std in
+           let+ () = Arg.return () in
+           print_endline "Hello, world!")
+      ;;
+    ]} *)
 val make : ?readme:(unit -> string) -> 'a Arg.t -> summary:string -> 'a t
 
+(** Create a group of subcommands with a common summary.
+
+    - [default] is an optional default command to run if no subcommand is
+      specified.
+    - [readme] is an optional function that returns a detailed description of
+      the command group.
+    - [summary] is a short description of what the command group does.
+    - The subcommands are provided as a list of (name, command) pairs.
+
+    Example of a group with no default command:
+    {[
+      let cmd_group =
+        Command.group
+          ~summary:"A group of related commands"
+          [ "hello", hello_cmd; "goodbye", goodbye_cmd ]
+      ;;
+    ]}
+
+    Each command in the group may itself be a group, allowing for hierarchical
+    trees of commands. *)
 val group
   :  ?default:'a Arg.t
   -> ?readme:(unit -> string)

--- a/lib/cmdlang_stdlib_runner/src/parser_state.ml
+++ b/lib/cmdlang_stdlib_runner/src/parser_state.ml
@@ -48,6 +48,8 @@ let make_docv param ~docv =
   Printf.sprintf "<%s>" docv
 ;;
 
+let make_doc ~doc = doc
+
 let compile
   : type a.
     a Arg_state.t
@@ -70,12 +72,15 @@ let compile
       aux f;
       aux x
     | Flag { names = hd :: tl; doc; var } ->
+      let doc = make_doc ~doc in
       hd :: tl |> List.iter (fun name -> emit (make_key ~name, Arg.Set var, " " ^ doc))
     | Flag_count { names = hd :: tl; doc; var } ->
+      let doc = make_doc ~doc in
       hd :: tl
       |> List.iter (fun name ->
         emit (make_key ~name, Arg.Unit (fun () -> incr var), " " ^ doc))
     | Named { names = hd :: tl; param; docv; doc; var } ->
+      let doc = make_doc ~doc in
       let docv = make_docv param ~docv in
       hd :: tl
       |> List.iter (fun name ->
@@ -84,6 +89,7 @@ let compile
           , make_arg_spec ~name param ~with_var:(fun s -> var := Some s)
           , docv ^ " " ^ doc ))
     | Named_multi { names = hd :: tl; param; docv; doc; rev_var } ->
+      let doc = make_doc ~doc in
       let docv = make_docv param ~docv in
       hd :: tl
       |> List.iter (fun name ->
@@ -92,6 +98,7 @@ let compile
           , make_arg_spec ~name param ~with_var:(fun s -> rev_var := s :: !rev_var)
           , docv ^ " " ^ doc ))
     | Named_opt { names = hd :: tl; param; docv; doc; var } ->
+      let doc = make_doc ~doc in
       let docv = make_docv param ~docv in
       hd :: tl
       |> List.iter (fun name ->
@@ -100,6 +107,7 @@ let compile
           , make_arg_spec ~name param ~with_var:(fun s -> var := Some s)
           , docv ^ " " ^ doc ))
     | Named_with_default { names = hd :: tl; param; default = _; docv; doc; var } ->
+      let doc = make_doc ~doc in
       let docv = make_docv param ~docv in
       hd :: tl
       |> List.iter (fun name ->
@@ -108,19 +116,23 @@ let compile
           , make_arg_spec ~name param ~with_var:(fun s -> var := Some s)
           , docv ^ " " ^ doc ))
     | Pos { pos; param; docv; doc; var } ->
+      let doc = make_doc ~doc in
       pos_state
       := Positional_state.One_pos.T { pos; param; docv; doc; presence = Required; var }
          :: !pos_state
     | Pos_opt { pos; param; docv; doc; var } ->
+      let doc = make_doc ~doc in
       pos_state
       := Positional_state.One_pos.T { pos; param; docv; doc; presence = Optional; var }
          :: !pos_state
     | Pos_with_default { pos; param; default; docv; doc; var } ->
+      let doc = make_doc ~doc in
       pos_state
       := Positional_state.One_pos.T
            { pos; param; docv; doc; presence = With_default default; var }
          :: !pos_state
     | Pos_all { param; docv; doc; rev_var } ->
+      let doc = make_doc ~doc in
       pos_all_state := Some (Positional_state.Pos_all.T { param; docv; doc; rev_var })
   in
   aux t;

--- a/lib/cmdlang_stdlib_runner/src/parser_state.ml
+++ b/lib/cmdlang_stdlib_runner/src/parser_state.ml
@@ -41,6 +41,17 @@ let make_key ~name =
   else "--" ^ name
 ;;
 
+module Arg_presence = struct
+  type 'a t =
+    | Required
+    | Optional
+    | Repeated
+    | With_default of
+        { param : 'a Ast.Param.t
+        ; default : 'a
+        }
+end
+
 let ( let* ) = Result.bind
 
 let make_docv param ~docv =
@@ -48,7 +59,17 @@ let make_docv param ~docv =
   Printf.sprintf "<%s>" docv
 ;;
 
-let make_doc ~doc = doc
+let make_doc (type a) ~doc ~arg_presence =
+  Printf.sprintf
+    "%s (%s)"
+    doc
+    (match (arg_presence : a Arg_presence.t) with
+     | Required -> "required"
+     | Optional -> "optional"
+     | Repeated -> "repeated"
+     | With_default { param; default } ->
+       Printf.sprintf "default %s" (Param_parser.print param default))
+;;
 
 let compile
   : type a.
@@ -59,7 +80,8 @@ let compile
   let r = ref [] in
   let pos_state = ref [] in
   let pos_all_state = ref None in
-  let emit s = r := s :: !r in
+  let emit_named s = r := s :: !r in
+  let emit_pos pos = pos_state := Positional_state.One_pos.T pos :: !pos_state in
   let rec aux : type a. a Arg_state.t -> unit =
     fun t ->
     match t with
@@ -72,67 +94,61 @@ let compile
       aux f;
       aux x
     | Flag { names = hd :: tl; doc; var } ->
-      let doc = make_doc ~doc in
-      hd :: tl |> List.iter (fun name -> emit (make_key ~name, Arg.Set var, " " ^ doc))
+      let doc = make_doc ~doc ~arg_presence:Optional in
+      hd :: tl
+      |> List.iter (fun name -> emit_named (make_key ~name, Arg.Set var, " " ^ doc))
     | Flag_count { names = hd :: tl; doc; var } ->
-      let doc = make_doc ~doc in
+      let doc = make_doc ~doc ~arg_presence:Repeated in
       hd :: tl
       |> List.iter (fun name ->
-        emit (make_key ~name, Arg.Unit (fun () -> incr var), " " ^ doc))
+        emit_named (make_key ~name, Arg.Unit (fun () -> incr var), " " ^ doc))
     | Named { names = hd :: tl; param; docv; doc; var } ->
-      let doc = make_doc ~doc in
+      let doc = make_doc ~doc ~arg_presence:Required in
       let docv = make_docv param ~docv in
       hd :: tl
       |> List.iter (fun name ->
-        emit
+        emit_named
           ( make_key ~name
           , make_arg_spec ~name param ~with_var:(fun s -> var := Some s)
           , docv ^ " " ^ doc ))
     | Named_multi { names = hd :: tl; param; docv; doc; rev_var } ->
-      let doc = make_doc ~doc in
+      let doc = make_doc ~doc ~arg_presence:Repeated in
       let docv = make_docv param ~docv in
       hd :: tl
       |> List.iter (fun name ->
-        emit
+        emit_named
           ( make_key ~name
           , make_arg_spec ~name param ~with_var:(fun s -> rev_var := s :: !rev_var)
           , docv ^ " " ^ doc ))
     | Named_opt { names = hd :: tl; param; docv; doc; var } ->
-      let doc = make_doc ~doc in
+      let doc = make_doc ~doc ~arg_presence:Optional in
       let docv = make_docv param ~docv in
       hd :: tl
       |> List.iter (fun name ->
-        emit
+        emit_named
           ( make_key ~name
           , make_arg_spec ~name param ~with_var:(fun s -> var := Some s)
           , docv ^ " " ^ doc ))
-    | Named_with_default { names = hd :: tl; param; default = _; docv; doc; var } ->
-      let doc = make_doc ~doc in
+    | Named_with_default { names = hd :: tl; param; default; docv; doc; var } ->
+      let doc = make_doc ~doc ~arg_presence:(With_default { param; default }) in
       let docv = make_docv param ~docv in
       hd :: tl
       |> List.iter (fun name ->
-        emit
+        emit_named
           ( make_key ~name
           , make_arg_spec ~name param ~with_var:(fun s -> var := Some s)
           , docv ^ " " ^ doc ))
     | Pos { pos; param; docv; doc; var } ->
-      let doc = make_doc ~doc in
-      pos_state
-      := Positional_state.One_pos.T { pos; param; docv; doc; presence = Required; var }
-         :: !pos_state
+      let doc = make_doc ~doc ~arg_presence:Required in
+      emit_pos { pos; param; docv; doc; var }
     | Pos_opt { pos; param; docv; doc; var } ->
-      let doc = make_doc ~doc in
-      pos_state
-      := Positional_state.One_pos.T { pos; param; docv; doc; presence = Optional; var }
-         :: !pos_state
+      let doc = make_doc ~doc ~arg_presence:Optional in
+      emit_pos { pos; param; docv; doc; var }
     | Pos_with_default { pos; param; default; docv; doc; var } ->
-      let doc = make_doc ~doc in
-      pos_state
-      := Positional_state.One_pos.T
-           { pos; param; docv; doc; presence = With_default default; var }
-         :: !pos_state
+      let doc = make_doc ~doc ~arg_presence:(With_default { param; default }) in
+      emit_pos { pos; param; docv; doc; var }
     | Pos_all { param; docv; doc; rev_var } ->
-      let doc = make_doc ~doc in
+      let doc = make_doc ~doc ~arg_presence:Repeated in
       pos_all_state := Some (Positional_state.Pos_all.T { param; docv; doc; rev_var })
   in
   aux t;

--- a/lib/cmdlang_stdlib_runner/src/positional_state.mli
+++ b/lib/cmdlang_stdlib_runner/src/positional_state.mli
@@ -5,20 +5,12 @@
     is used to collect and store the values of positional arguments during the
     calls to [Arg.anon_fun]. *)
 
-module Presence : sig
-  type 'a t =
-    | Required
-    | Optional
-    | With_default of 'a
-end
-
 module One_pos : sig
   type 'a t =
     { pos : int
     ; param : 'a Ast.Param.t
     ; docv : string option
     ; doc : string
-    ; presence : 'a Presence.t
     ; var : 'a option ref
     }
 

--- a/lib/cmdlang_to_base/src/translate.ml
+++ b/lib/cmdlang_to_base/src/translate.ml
@@ -66,7 +66,8 @@ module Arg = struct
     | None -> Param.docv param |> Option.value ~default:"VAL"
   ;;
 
-  let doc_of_param ~docv ~doc ~param = docv_of_param ~docv ~param ^ " " ^ doc
+  let fmt_doc ~doc = doc
+  let doc_of_param ~docv ~doc ~param = docv_of_param ~docv ~param ^ " " ^ fmt_doc ~doc
 
   let translate_flag_names (hd :: tl : _ Nonempty_list.t) ~(config : Config.t) =
     let map_flag name = if String.length name = 1 then name else "--" ^ name in
@@ -113,6 +114,7 @@ module Arg = struct
         let x = aux x in
         Command.Param.apply f x
       | Flag { names; doc } ->
+        let doc = fmt_doc ~doc in
         let (name :: aliases) = translate_flag_names names ~config in
         let flag = Command.Flag.no_arg in
         Command.Param.flag ~aliases name flag ~doc

--- a/lib/cmdlang_to_climate/src/translate.ml
+++ b/lib/cmdlang_to_climate/src/translate.ml
@@ -82,18 +82,19 @@ module Arg = struct
         (hd :: tl)
         (param |> Param.translate)
         ~default
-    | Pos { pos; param; docv; doc = _ } ->
-      Climate.Arg_parser.pos_req ?value_name:docv pos (param |> Param.translate)
-    | Pos_opt { pos; param; docv; doc = _ } ->
-      Climate.Arg_parser.pos_opt ?value_name:docv pos (param |> Param.translate)
-    | Pos_with_default { pos; param; default; docv; doc = _ } ->
+    | Pos { pos; param; docv; doc } ->
+      Climate.Arg_parser.pos_req ~desc:doc ?value_name:docv pos (param |> Param.translate)
+    | Pos_opt { pos; param; docv; doc } ->
+      Climate.Arg_parser.pos_opt ~desc:doc ?value_name:docv pos (param |> Param.translate)
+    | Pos_with_default { pos; param; default; docv; doc } ->
       Climate.Arg_parser.pos_with_default
+        ~desc:doc
         ?value_name:docv
         pos
         (param |> Param.translate)
         ~default
-    | Pos_all { param; docv; doc = _ } ->
-      Climate.Arg_parser.pos_all ?value_name:docv (param |> Param.translate)
+    | Pos_all { param; docv; doc } ->
+      Climate.Arg_parser.pos_all ~desc:doc ?value_name:docv (param |> Param.translate)
   ;;
 end
 

--- a/lib/cmdlang_to_climate/src/translate.ml
+++ b/lib/cmdlang_to_climate/src/translate.ml
@@ -49,52 +49,73 @@ module Param = struct
 end
 
 module Arg = struct
+  let fmt_doc ~doc = doc
+
+  let make_desc : type a. doc:string -> param:a Ast.Param.t -> string =
+    fun ~doc ~param ->
+    match (param : _ Ast.Param.t) with
+    | Conv _ | String | Int | Float | Bool | File
+    | Enum { docv = _; choices = _; to_string = _ }
+    | Comma_separated _ -> fmt_doc ~doc
+  ;;
+
   let rec translate : type a. a Ast.Arg.t -> a Climate.Arg_parser.t = function
     | Return x -> Climate.Arg_parser.const x
     | Map { x; f } -> Climate.Arg_parser.map (translate x) ~f
     | Both (a, b) -> Climate.Arg_parser.both (translate a) (translate b)
     | Apply { f; x } -> Climate.Arg_parser.apply (translate f) (translate x)
-    | Flag { names = hd :: tl; doc } -> Climate.Arg_parser.flag ~desc:doc (hd :: tl)
+    | Flag { names = hd :: tl; doc } ->
+      let desc = fmt_doc ~doc in
+      Climate.Arg_parser.flag ~desc (hd :: tl)
     | Flag_count { names = hd :: tl; doc } ->
-      Climate.Arg_parser.flag_count ~desc:doc (hd :: tl)
+      let desc = fmt_doc ~doc in
+      Climate.Arg_parser.flag_count ~desc (hd :: tl)
     | Named { names = hd :: tl; param; docv; doc } ->
+      let desc = make_desc ~doc ~param in
       Climate.Arg_parser.named_req
-        ~desc:doc
+        ~desc
         ?value_name:docv
         (hd :: tl)
         (param |> Param.translate)
     | Named_multi { names = hd :: tl; param; docv; doc } ->
+      let desc = make_desc ~doc ~param in
       Climate.Arg_parser.named_multi
-        ~desc:doc
+        ~desc
         ?value_name:docv
         (hd :: tl)
         (param |> Param.translate)
     | Named_opt { names = hd :: tl; param; docv; doc } ->
+      let desc = make_desc ~doc ~param in
       Climate.Arg_parser.named_opt
-        ~desc:doc
+        ~desc
         ?value_name:docv
         (hd :: tl)
         (param |> Param.translate)
     | Named_with_default { names = hd :: tl; param; default; docv; doc } ->
+      let desc = make_desc ~doc ~param in
       Climate.Arg_parser.named_with_default
-        ~desc:doc
+        ~desc
         ?value_name:docv
         (hd :: tl)
         (param |> Param.translate)
         ~default
     | Pos { pos; param; docv; doc } ->
-      Climate.Arg_parser.pos_req ~desc:doc ?value_name:docv pos (param |> Param.translate)
+      let desc = make_desc ~doc ~param in
+      Climate.Arg_parser.pos_req ~desc ?value_name:docv pos (param |> Param.translate)
     | Pos_opt { pos; param; docv; doc } ->
-      Climate.Arg_parser.pos_opt ~desc:doc ?value_name:docv pos (param |> Param.translate)
+      let desc = make_desc ~doc ~param in
+      Climate.Arg_parser.pos_opt ~desc ?value_name:docv pos (param |> Param.translate)
     | Pos_with_default { pos; param; default; docv; doc } ->
+      let desc = make_desc ~doc ~param in
       Climate.Arg_parser.pos_with_default
-        ~desc:doc
+        ~desc
         ?value_name:docv
         pos
         (param |> Param.translate)
         ~default
     | Pos_all { param; docv; doc } ->
-      Climate.Arg_parser.pos_all ~desc:doc ?value_name:docv (param |> Param.translate)
+      let desc = make_desc ~doc ~param in
+      Climate.Arg_parser.pos_all ~desc ?value_name:docv (param |> Param.translate)
   ;;
 end
 

--- a/lib/cmdlang_to_cmdliner/src/translate.mli
+++ b/lib/cmdlang_to_cmdliner/src/translate.mli
@@ -19,7 +19,6 @@ module Private : sig
       change in breaking ways without any notice. Do not use. *)
 
   module Arg : sig
-    val with_dot_suffix : doc:string -> string
     val doc_of_param : doc:string -> param:'a Ast.Param.t -> string
   end
 

--- a/test/cram/basic.t
+++ b/test/cram/basic.t
@@ -18,7 +18,7 @@ String.
   Usage: ./main_climate.exe basic string [OPTIONS] <STRING>
   
   Arguments:
-    <STRING>  
+    <STRING>  value
   
   Options:
     -h, --help  Print help
@@ -102,7 +102,7 @@ Int.
   Usage: ./main_climate.exe basic int [OPTIONS] <INT>
   
   Arguments:
-    <INT>  
+    <INT>  value
   
   Options:
     -h, --help  Print help
@@ -223,7 +223,7 @@ Float.
   Usage: ./main_climate.exe basic float [OPTIONS] <FLOAT>
   
   Arguments:
-    <FLOAT>  
+    <FLOAT>  value
   
   Options:
     -h, --help  Print help
@@ -344,7 +344,7 @@ Bool.
   Usage: ./main_climate.exe basic bool [OPTIONS] <BOOL>
   
   Arguments:
-    <BOOL>  
+    <BOOL>  value
   
   Options:
     -h, --help  Print help
@@ -519,7 +519,7 @@ File.
   Usage: ./main_climate.exe basic file [OPTIONS] <FILE>
   
   Arguments:
-    <FILE>  
+    <FILE>  value
   
   Options:
     -h, --help  Print help

--- a/test/cram/basic.t
+++ b/test/cram/basic.t
@@ -13,12 +13,15 @@ String.
   
 
   $ ./main_climate.exe basic string --help
-  Usage: ./main_climate.exe basic string [OPTIONS] <STRING>
-  
   print string
   
+  Usage: ./main_climate.exe basic string [OPTIONS] <STRING>
+  
+  Arguments:
+    <STRING>  
+  
   Options:
-   --help, -h   Print help
+    -h, --help  Print help
 
   $ ./main_cmdliner.exe basic string --help=plain
   NAME
@@ -94,12 +97,15 @@ Int.
   
 
   $ ./main_climate.exe basic int --help
-  Usage: ./main_climate.exe basic int [OPTIONS] <INT>
-  
   print int
   
+  Usage: ./main_climate.exe basic int [OPTIONS] <INT>
+  
+  Arguments:
+    <INT>  
+  
   Options:
-   --help, -h   Print help
+    -h, --help  Print help
 
   $ ./main_cmdliner.exe basic int --help=plain
   NAME
@@ -212,12 +218,15 @@ Float.
   
 
   $ ./main_climate.exe basic float --help
-  Usage: ./main_climate.exe basic float [OPTIONS] <FLOAT>
-  
   print float
   
+  Usage: ./main_climate.exe basic float [OPTIONS] <FLOAT>
+  
+  Arguments:
+    <FLOAT>  
+  
   Options:
-   --help, -h   Print help
+    -h, --help  Print help
 
   $ ./main_cmdliner.exe basic float --help=plain
   NAME
@@ -330,12 +339,15 @@ Bool.
   
 
   $ ./main_climate.exe basic bool --help
-  Usage: ./main_climate.exe basic bool [OPTIONS] <BOOL>
-  
   print bool
   
+  Usage: ./main_climate.exe basic bool [OPTIONS] <BOOL>
+  
+  Arguments:
+    <BOOL>  
+  
   Options:
-   --help, -h   Print help
+    -h, --help  Print help
 
   $ ./main_cmdliner.exe basic bool --help=plain
   NAME
@@ -502,12 +514,15 @@ File.
   
 
   $ ./main_climate.exe basic file --help
-  Usage: ./main_climate.exe basic file [OPTIONS] <FILE>
-  
   print file
   
+  Usage: ./main_climate.exe basic file [OPTIONS] <FILE>
+  
+  Arguments:
+    <FILE>  
+  
   Options:
-   --help, -h   Print help
+    -h, --help  Print help
 
   $ ./main_cmdliner.exe basic file --help=plain
   NAME

--- a/test/cram/const.t
+++ b/test/cram/const.t
@@ -11,12 +11,12 @@ Checking the help when there are no arguments.
   
 
   $ ./main_climate.exe return --help
-  Usage: ./main_climate.exe return [OPTIONS]
-  
   An empty command
   
+  Usage: ./main_climate.exe return [OPTIONS]
+  
   Options:
-   --help, -h   Print help
+    -h, --help  Print help
 
   $ ./main_cmdliner.exe return --help=plain
   NAME

--- a/test/cram/doc.t
+++ b/test/cram/doc.t
@@ -243,7 +243,7 @@ integrates best with its formatting of help pages.
   Args doc end with dots
   
   Arguments:
-    <STRING>  The doc for [a] in the code ends with a dot (required)
+    <STRING>  The doc for [a] in the code ends with a dot. (required)
     <STRING>  The doc for [b] doesn't (required)
   
   Options:

--- a/test/cram/doc.t
+++ b/test/cram/doc.t
@@ -170,10 +170,10 @@ A singleton command with a readme:
     -help   Display this list of options
     --help  Display this list of options
 
-Arguments doc created with or without dots at the end. Positional arguments are
-currently not documented in the help output of the base and climate commands,
-but they are in the cmdliner command. In cmdliner, we currently add the trailing
-dot to the documentation string if it is not present.
+Positional arguments are currently not documented in the help output of the base
+commands. Cmdlang recommmand for arguments doc to be created without dots at the
+end. A dot is systematically added when translating to cmdliner since this
+integrates best with its formatting of help pages.
 
   $ ./main_base.exe doc args-doc-end-with-dots --help
   Args doc end with dots

--- a/test/cram/doc.t
+++ b/test/cram/doc.t
@@ -13,20 +13,20 @@
   
 
   $ ./main_climate.exe doc --help
-  Usage: ./main_climate.exe doc [OPTIONS]
-         ./main_climate.exe doc [SUBCOMMAND]
-  
   Testing documentation features
   
   This group is dedicated to testing documentation features.
       
   
-  Options:
-   --help, -h   Print help
+  Usage: ./main_climate.exe doc [COMMAND]
+         ./main_climate.exe doc [OPTIONS]
   
-  Subcommands:
-   args-doc-end-with-dots  Args doc end with dots
-   singleton-with-readme  Singleton command with a readme
+  Options:
+    -h, --help  Print help
+  
+  Commands:
+    args-doc-end-with-dots  Args doc end with dots
+    singleton-with-readme   Singleton command with a readme
   
   This is a readme.
   It can be written on multiple lines.
@@ -107,16 +107,16 @@ A singleton command with a readme:
   
 
   $ ./main_climate.exe doc singleton-with-readme --help
-  Usage: ./main_climate.exe doc singleton-with-readme [OPTIONS]
-  
   Singleton command with a readme
   
   This is a readme.
   It can be written on multiple lines.
   
   
+  Usage: ./main_climate.exe doc singleton-with-readme [OPTIONS]
+  
   Options:
-   --help, -h   Print help
+    -h, --help  Print help
 
   $ ./main_cmdliner.exe doc singleton-with-readme --help=plain
   NAME
@@ -186,12 +186,16 @@ dot to the documentation string if it is not present.
   
 
   $ ./main_climate.exe doc args-doc-end-with-dots --help
-  Usage: ./main_climate.exe doc args-doc-end-with-dots [OPTIONS] <STRING> <STRING>
-  
   Args doc end with dots
   
+  Usage: ./main_climate.exe doc args-doc-end-with-dots [OPTIONS] <STRING> <STRING>
+  
+  Arguments:
+    <STRING>  
+    <STRING>  
+  
   Options:
-   --help, -h   Print help
+    -h, --help  Print help
 
   $ ./main_cmdliner.exe doc args-doc-end-with-dots --help=plain
   NAME

--- a/test/cram/doc.t
+++ b/test/cram/doc.t
@@ -191,8 +191,8 @@ dot to the documentation string if it is not present.
   Usage: ./main_climate.exe doc args-doc-end-with-dots [OPTIONS] <STRING> <STRING>
   
   Arguments:
-    <STRING>  
-    <STRING>  
+    <STRING>  The doc for [a] in the code ends with a dot.
+    <STRING>  The doc for [b] doesn't
   
   Options:
     -h, --help  Print help

--- a/test/cram/enum.t
+++ b/test/cram/enum.t
@@ -1,0 +1,240 @@
+Characterizing translation and behavior of enumerated types.
+
+Base.
+
+  $ ./main_base.exe enum pos --help
+  print color
+  
+    main_base.exe enum pos COLOR
+  
+  === flags ===
+  
+    [-help], -?                . print this help text and exit
+  
+
+  $ ./main_base.exe enum pos red
+  red
+
+  $ ./main_base.exe enum pos INVALID
+  Error parsing command line:
+  
+    failed to parse COLOR value "INVALID"
+    (Failure "valid arguments: {blue,green,red}")
+  
+  For usage information, run
+  
+    main_base.exe enum pos -help
+  
+  [1]
+
+  $ ./main_base.exe enum named --help
+  print color
+  
+    main_base.exe enum named 
+  
+  === flags ===
+  
+    --color COLOR              . color
+    [-help], -?                . print this help text and exit
+  
+
+  $ ./main_base.exe enum named --color red
+  red
+
+  $ ./main_base.exe enum named --color INVALID
+  Error parsing command line:
+  
+    failed to parse --color value "INVALID".
+    (Failure "valid arguments: {blue,green,red}")
+  
+  For usage information, run
+  
+    main_base.exe enum named -help
+  
+  [1]
+
+Climate.
+
+  $ ./main_climate.exe enum pos --help
+  print color
+  
+  Usage: ./main_climate.exe enum pos [OPTIONS] <COLOR>
+  
+  Arguments:
+    <COLOR>  color
+  
+  Options:
+    -h, --help  Print help
+
+  $ ./main_climate.exe enum pos red
+  red
+
+  $ ./main_climate.exe enum pos INVALID
+  Failed to parse the argument at position 0: invalid value: "INVALID" (valid values are: red, green, blue)
+  [124]
+
+  $ ./main_climate.exe enum named --help
+  print color
+  
+  Usage: ./main_climate.exe enum named [OPTIONS]
+  
+  Options:
+        --color <COLOR>  color
+    -h, --help           Print help
+
+  $ ./main_climate.exe enum named --color red
+  red
+
+  $ ./main_climate.exe enum named --color INVALID
+  Failed to parse the argument to "--color": invalid value: "INVALID" (valid values are: red, green, blue)
+  [124]
+
+Cmdliner.
+
+  $ ./main_cmdliner.exe enum pos --help=plain
+  NAME
+         ./main_cmdliner.exe-enum-pos - print color
+  
+  SYNOPSIS
+         ./main_cmdliner.exe enum pos [OPTION]… COLOR
+  
+  ARGUMENTS
+         COLOR (required)
+             color. COLOR must be one of 'red', 'green' or 'blue'.
+  
+  COMMON OPTIONS
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         ./main_cmdliner.exe enum pos exits with:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  SEE ALSO
+         ./main_cmdliner.exe(1)
+  
+
+  $ ./main_cmdliner.exe enum pos red
+  red
+
+  $ ./main_cmdliner.exe enum pos INVALID
+  ./main_cmdliner.exe: COLOR argument: invalid value 'INVALID', expected one of
+                       'red', 'green' or 'blue'
+  Usage: ./main_cmdliner.exe enum pos [OPTION]… COLOR
+  Try './main_cmdliner.exe enum pos --help' or './main_cmdliner.exe --help' for more information.
+  [124]
+
+  $ ./main_cmdliner.exe enum named --help=plain
+  NAME
+         ./main_cmdliner.exe-enum-named - print color
+  
+  SYNOPSIS
+         ./main_cmdliner.exe enum named [--color=COLOR] [OPTION]…
+  
+  OPTIONS
+         --color=COLOR (required)
+             color. COLOR must be one of 'red', 'green' or 'blue'.
+  
+  COMMON OPTIONS
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         ./main_cmdliner.exe enum named exits with:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  SEE ALSO
+         ./main_cmdliner.exe(1)
+  
+
+  $ ./main_cmdliner.exe enum named --color red
+  red
+
+  $ ./main_cmdliner.exe enum named --color INVALID
+  ./main_cmdliner.exe: option '--color': invalid value 'INVALID', expected one
+                       of 'red', 'green' or 'blue'
+  Usage: ./main_cmdliner.exe enum named [--color=COLOR] [OPTION]…
+  Try './main_cmdliner.exe enum named --help' or './main_cmdliner.exe --help' for more information.
+  [124]
+
+Stdlib runner.
+
+  $ ./main_stdlib_runner.exe enum pos --help
+  Usage: ./main_stdlib_runner.exe enum pos [OPTIONS] [ARGUMENTS]
+  
+  print color
+  
+  Arguments:
+    <COLOR>  color (required)
+  
+  Options:
+    -help   Display this list of options
+    --help  Display this list of options
+
+  $ ./main_stdlib_runner.exe enum pos red
+  red
+
+  $ ./main_stdlib_runner.exe enum pos INVALID
+  pos: Failed to parse the argument at position 0: invalid value "INVALID" (not a valid choice).
+  Usage: ./main_stdlib_runner.exe enum pos [OPTIONS] [ARGUMENTS]
+  
+  print color
+  
+  Arguments:
+    <COLOR>  color (required)
+  
+  Options:
+    -help   Display this list of options
+    --help  Display this list of options
+  [2]
+
+  $ ./main_stdlib_runner.exe enum named --help
+  Usage: ./main_stdlib_runner.exe enum named [OPTIONS]
+  
+  print color
+  
+  Options:
+    --color {red|green|blue}
+     <COLOR> color (required)
+    -help   Display this list of options
+    --help  Display this list of options
+
+  $ ./main_stdlib_runner.exe enum named --color red
+  red
+
+  $ ./main_stdlib_runner.exe enum named --color INVALID
+  named: wrong argument 'INVALID'; option '--color' expects one of: red green blue.
+  Usage: ./main_stdlib_runner.exe enum named [OPTIONS]
+  
+  print color
+  
+  Options:
+    --color {red|green|blue}
+     <COLOR> color (required)
+    -help   Display this list of options
+    --help  Display this list of options
+  [2]

--- a/test/cram/main-help.t
+++ b/test/cram/main-help.t
@@ -17,22 +17,22 @@ the executable for each backend.
   
 
   $ ./main_climate.exe --help
-  Usage: ./main_climate.exe [OPTIONS]
-         ./main_climate.exe [SUBCOMMAND]
-  
   Cram Test Command
   
-  Options:
-   --help, -h   Print help
+  Usage: ./main_climate.exe [COMMAND]
+         ./main_climate.exe [OPTIONS]
   
-  Subcommands:
-   basic  Basic types
-   doc  Testing documentation features
+  Options:
+    -h, --help  Print help
+  
+  Commands:
+    basic   Basic types
+    doc     Testing documentation features
   
   This group is dedicated to testing documentation features.
       
-   named  Named arguments
-   return  An empty command
+    named   Named arguments
+    return  An empty command
 
   $ ./main_cmdliner.exe --help=plain
   NAME

--- a/test/cram/main-help.t
+++ b/test/cram/main-help.t
@@ -10,6 +10,7 @@ the executable for each backend.
   
     basic                      . Basic types
     doc                        . Testing documentation features
+    enum                       . Enum types
     named                      . Named arguments
     return                     . An empty command
     version                    . print version information
@@ -27,6 +28,7 @@ the executable for each backend.
   
   Commands:
     basic   Basic types
+    enum    Enum types
     doc     Testing documentation features
   
   This group is dedicated to testing documentation features.
@@ -47,6 +49,9 @@ the executable for each backend.
   
          doc COMMAND …
              Testing documentation features
+  
+         enum COMMAND …
+             Enum types
   
          named COMMAND …
              Named arguments
@@ -82,6 +87,7 @@ the executable for each backend.
   
   Subcommands:
     basic      Basic types
+    enum       Enum types
     doc        Testing documentation features
     named      Named arguments
     return     An empty command

--- a/test/cram/named-opt.t
+++ b/test/cram/named-opt.t
@@ -64,7 +64,7 @@ Let's start with characterizing whether and how the default value appears in the
   Named_opt__string_with_docv
   
   Options:
-    --who <WHO> Hello WHO?
+    --who <WHO> Hello WHO? (optional)
     -help       Display this list of options
     --help      Display this list of options
 
@@ -157,7 +157,7 @@ Characterizing the flag documentation when the `docv` parameter is not supplied.
   Named_opt__string_without_docv
   
   Options:
-    --who <STRING> Hello WHO?
+    --who <STRING> Hello WHO? (optional)
     -help          Display this list of options
     --help         Display this list of options
 

--- a/test/cram/named-opt.t
+++ b/test/cram/named-opt.t
@@ -14,13 +14,13 @@ Let's start with characterizing whether and how the default value appears in the
   
 
   $ ./main_climate.exe named opt string-with-docv --help
-  Usage: ./main_climate.exe named opt string-with-docv [OPTIONS]
-  
   Named_opt__string_with_docv
   
+  Usage: ./main_climate.exe named opt string-with-docv [OPTIONS]
+  
   Options:
-   --who <WHO>   Hello WHO?
-   --help, -h   Print help
+        --who <WHO>  Hello WHO?
+    -h, --help       Print help
 
   $ ./main_cmdliner.exe named opt string-with-docv --help=plain
   NAME
@@ -106,13 +106,13 @@ Characterizing the flag documentation when the `docv` parameter is not supplied.
   
 
   $ ./main_climate.exe named opt string-without-docv --help
-  Usage: ./main_climate.exe named opt string-without-docv [OPTIONS]
-  
   Named_opt__string_without_docv
   
+  Usage: ./main_climate.exe named opt string-without-docv [OPTIONS]
+  
   Options:
-   --who <STRING>   Hello WHO?
-   --help, -h   Print help
+        --who <STRING>  Hello WHO?
+    -h, --help          Print help
 
   $ ./main_cmdliner.exe named opt string-without-docv --help=plain
   NAME

--- a/test/cram/named-opt.t
+++ b/test/cram/named-opt.t
@@ -32,7 +32,7 @@ Let's start with characterizing whether and how the default value appears in the
   
   OPTIONS
          --who=WHO
-             Hello WHO?.
+             Hello WHO?
   
   COMMON OPTIONS
          --help[=FMT] (default=auto)
@@ -125,7 +125,7 @@ Characterizing the flag documentation when the `docv` parameter is not supplied.
   
   OPTIONS
          --who=STRING
-             Hello WHO?.
+             Hello WHO?
   
   COMMON OPTIONS
          --help[=FMT] (default=auto)

--- a/test/cram/named-with-default.t
+++ b/test/cram/named-with-default.t
@@ -20,13 +20,13 @@ At the moment, the default value is not displayed in the help page for the
 help page.
 
   $ ./main_climate.exe named with-default string --help
-  Usage: ./main_climate.exe named with-default string [OPTIONS]
-  
   Named_with_default__string
   
+  Usage: ./main_climate.exe named with-default string [OPTIONS]
+  
   Options:
-   --who <WHO>   Hello WHO?
-   --help, -h   Print help
+        --who <WHO>  Hello WHO?
+    -h, --help       Print help
 
 In the cmdliner backend, the default value is shown next to the option, in
 parentheses. See `(absent=...)` below.
@@ -184,13 +184,13 @@ functions or parsers generated from modules with utils.
   
 
   $ ./main_climate.exe named with-default create --help
-  Usage: ./main_climate.exe named with-default create [OPTIONS]
-  
   Named_with_default__create
   
+  Usage: ./main_climate.exe named with-default create [OPTIONS]
+  
   Options:
-   --who <(A|B)>   Greet A or B?
-   --help, -h   Print help
+        --who <(A|B)>  Greet A or B?
+    -h, --help         Print help
 
   $ ./main_cmdliner.exe named with-default create --help=plain
   NAME
@@ -253,13 +253,13 @@ Named-with-default with a stringable parameter.
   
 
   $ ./main_climate.exe named with-default stringable --help
-  Usage: ./main_climate.exe named with-default stringable [OPTIONS]
-  
   Named_with_default__stringable
   
+  Usage: ./main_climate.exe named with-default stringable [OPTIONS]
+  
   Options:
-   --who <VAL>   identifier
-   --help, -h   Print help
+        --who <VAL>  identifier
+    -h, --help       Print help
 
   $ ./main_cmdliner.exe named with-default stringable --help=plain
   NAME
@@ -336,13 +336,13 @@ Named-with-default with a validated string parameter.
   
 
   $ ./main_climate.exe named with-default validated --help
-  Usage: ./main_climate.exe named with-default validated [OPTIONS]
-  
   Named_with_default__validated
   
+  Usage: ./main_climate.exe named with-default validated [OPTIONS]
+  
   Options:
-   --who <VAL>   4 letters alphanumerical identifier
-   --help, -h   Print help
+        --who <VAL>  4 letters alphanumerical identifier
+    -h, --help       Print help
 
   $ ./main_cmdliner.exe named with-default validated --help=plain
   NAME
@@ -470,13 +470,13 @@ Named-with-default with a comma-separated string parameter.
   
 
   $ ./main_climate.exe named with-default comma-separated --help
-  Usage: ./main_climate.exe named with-default comma-separated [OPTIONS]
-  
   Named_with_default__comma_separated
   
+  Usage: ./main_climate.exe named with-default comma-separated [OPTIONS]
+  
   Options:
-   --who <STRING>   Hello WHO?
-   --help, -h   Print help
+        --who <STRING>  Hello WHO?
+    -h, --help          Print help
 
   $ ./main_cmdliner.exe named with-default comma-separated --help=plain
   NAME

--- a/test/cram/named-with-default.t
+++ b/test/cram/named-with-default.t
@@ -41,7 +41,7 @@ parentheses. See `(absent=...)` below.
   
   OPTIONS
          --who=WHO (absent=World)
-             Hello WHO?.
+             Hello WHO?
   
   COMMON OPTIONS
          --help[=FMT] (default=auto)
@@ -203,7 +203,7 @@ functions or parsers generated from modules with utils.
   
   OPTIONS
          --who=(A|B) (absent=A)
-             Greet A or B?.
+             Greet A or B?
   
   COMMON OPTIONS
          --help[=FMT] (default=auto)

--- a/test/cram/named-with-default.t
+++ b/test/cram/named-with-default.t
@@ -73,7 +73,7 @@ parentheses. See `(absent=...)` below.
   Named_with_default__string
   
   Options:
-    --who <WHO> Hello WHO?
+    --who <WHO> Hello WHO? (default World)
     -help       Display this list of options
     --help      Display this list of options
 
@@ -165,7 +165,7 @@ functions or parsers generated from modules with utils.
   Named_with_default__create
   
   Options:
-    --who <(A|B)> Greet A or B?
+    --who <(A|B)> Greet A or B? (default A)
     -help         Display this list of options
     --help        Display this list of options
   [2]
@@ -235,7 +235,7 @@ functions or parsers generated from modules with utils.
   Named_with_default__create
   
   Options:
-    --who <(A|B)> Greet A or B?
+    --who <(A|B)> Greet A or B? (default A)
     -help         Display this list of options
     --help        Display this list of options
 
@@ -304,7 +304,7 @@ Named-with-default with a stringable parameter.
   Named_with_default__stringable
   
   Options:
-    --who <VAL> identifier
+    --who <VAL> identifier (default my-id)
     -help       Display this list of options
     --help      Display this list of options
 
@@ -387,7 +387,7 @@ Named-with-default with a validated string parameter.
   Named_with_default__validated
   
   Options:
-    --who <VAL> 4 letters alphanumerical identifier
+    --who <VAL> 4 letters alphanumerical identifier (default 0000)
     -help       Display this list of options
     --help      Display this list of options
 
@@ -437,7 +437,7 @@ Invalid entry for the validated string parameter.
   Named_with_default__validated
   
   Options:
-    --who <VAL> 4 letters alphanumerical identifier
+    --who <VAL> 4 letters alphanumerical identifier (default 0000)
     -help       Display this list of options
     --help      Display this list of options
   [2]
@@ -521,7 +521,7 @@ Named-with-default with a comma-separated string parameter.
   Named_with_default__comma_separated
   
   Options:
-    --who <STRING> Hello WHO?
+    --who <STRING> Hello WHO? (default World)
     -help          Display this list of options
     --help         Display this list of options
 

--- a/test/cram/src/cmd.ml
+++ b/test/cram/src/cmd.ml
@@ -54,6 +54,43 @@ module Basic = struct
   ;;
 end
 
+module Enum = struct
+  module Color = struct
+    type t =
+      | Red
+      | Green
+      | Blue
+
+    let all = [ Red; Green; Blue ]
+
+    let to_string = function
+      | Red -> "red"
+      | Green -> "green"
+      | Blue -> "blue"
+    ;;
+  end
+
+  let color_param = Command.Param.enumerated ~docv:"COLOR" (module Color)
+
+  let pos =
+    Command.make
+      ~summary:"print color"
+      (let open Command.Std in
+       let+ color = Arg.pos ~pos:0 color_param ~doc:"color" in
+       print_endline (Color.to_string color))
+  ;;
+
+  let named =
+    Command.make
+      ~summary:"print color"
+      (let open Command.Std in
+       let+ color = Arg.named [ "color" ] color_param ~doc:"color" in
+       print_endline (Color.to_string color))
+  ;;
+
+  let main = Command.group ~summary:"Enum types" [ "named", named; "pos", pos ]
+end
+
 module Doc = struct
   let singleton_with_readme =
     Command.make
@@ -290,5 +327,10 @@ end
 let main =
   Command.group
     ~summary:"Cram Test Command"
-    [ "basic", Basic.main; "doc", Doc.main; "named", Named.main; "return", return ]
+    [ "basic", Basic.main
+    ; "enum", Enum.main
+    ; "doc", Doc.main
+    ; "named", Named.main
+    ; "return", return
+    ]
 ;;

--- a/test/expect/test__flag.ml
+++ b/test/expect/test__flag.ml
@@ -49,7 +49,7 @@ let%expect_test "flag" =
     eval-stdlib-runner
 
     Options:
-      --print-hello  print Hello
+      --print-hello  print Hello (optional)
       -help          Display this list of options
       --help         Display this list of options
     ("Evaluation Failed" ((exit_code 2)))
@@ -78,7 +78,7 @@ let%expect_test "flag" =
     eval-stdlib-runner
 
     Options:
-      --print-hello  print Hello
+      --print-hello  print Hello (optional)
       -help          Display this list of options
       --help         Display this list of options
     ("Evaluation Failed" ((exit_code 2)))
@@ -102,7 +102,7 @@ let%expect_test "flag" =
     eval-stdlib-runner
 
     Options:
-      --print-hello  print Hello
+      --print-hello  print Hello (optional)
       -help          Display this list of options
       --help         Display this list of options
     ("Evaluation Failed" ((exit_code 2)))
@@ -161,7 +161,7 @@ let%expect_test "1-letter-flag" =
     eval-stdlib-runner
 
     Options:
-      -p      print Hello
+      -p      print Hello (optional)
       -help   Display this list of options
       --help  Display this list of options
     ("Evaluation Failed" ((exit_code 2)))
@@ -233,8 +233,8 @@ let%expect_test "1-letter-alias" =
     eval-stdlib-runner
 
     Options:
-      -p             print Hello
-      --print-hello  print Hello
+      -p             print Hello (optional)
+      --print-hello  print Hello (optional)
       -help          Display this list of options
       --help         Display this list of options
     ("Evaluation Failed" ((exit_code 2)))
@@ -304,8 +304,8 @@ let%expect_test "ambiguous prefixes" =
     eval-stdlib-runner
 
     Options:
-      --print-hello-world  print Hello World
-      --print-hello-you    print Hello You
+      --print-hello-world  print Hello World (optional)
+      --print-hello-you    print Hello You (optional)
       -help                Display this list of options
       --help               Display this list of options
     ("Evaluation Failed" ((exit_code 2)))
@@ -332,8 +332,8 @@ let%expect_test "ambiguous prefixes" =
     eval-stdlib-runner
 
     Options:
-      --print-hello-world  print Hello World
-      --print-hello-you    print Hello You
+      --print-hello-world  print Hello World (optional)
+      --print-hello-you    print Hello You (optional)
       -help                Display this list of options
       --help               Display this list of options
     ("Evaluation Failed" ((exit_code 2)))

--- a/test/expect/test__named.ml
+++ b/test/expect/test__named.ml
@@ -126,7 +126,7 @@ let%expect_test "1-letter-named" =
     eval-stdlib-runner
 
     Options:
-      -w <WHO> hello who?
+      -w <WHO> hello who? (required)
       -help    Display this list of options
       --help   Display this list of options
     ("Evaluation Failed" ((exit_code 2)))

--- a/test/expect/test__pos.ml
+++ b/test/expect/test__pos.ml
@@ -58,7 +58,7 @@ let%expect_test "skipping-pos" =
     ("Evaluation Raised" (
       Climate.Spec_error.E
       "Attempted to declare a parser with a gap in its positional arguments. No parser would interpret the argument at position 0 but there is a parser for at least one argument at a higher position."))
-    Attempted to declare a parser with a gap in its positional arguments. No parser would interpret the argument at position 0 but there is a parser for at least one argument at a higher position.----------------------------------------------------- Cmdliner
+    ----------------------------------------------------- Cmdliner
     test: required argument WHO is missing
     Usage: test [OPTION]… WHO
     Try 'test --help' for more information.
@@ -82,7 +82,7 @@ let%expect_test "skipping-pos" =
     ("Evaluation Raised" (
       Climate.Spec_error.E
       "Attempted to declare a parser with a gap in its positional arguments. No parser would interpret the argument at position 0 but there is a parser for at least one argument at a higher position."))
-    Attempted to declare a parser with a gap in its positional arguments. No parser would interpret the argument at position 0 but there is a parser for at least one argument at a higher position.----------------------------------------------------- Cmdliner
+    ----------------------------------------------------- Cmdliner
     test: required argument WHO is missing
     Usage: test [OPTION]… WHO
     Try 'test --help' for more information.
@@ -106,7 +106,7 @@ let%expect_test "skipping-pos" =
     ("Evaluation Raised" (
       Climate.Spec_error.E
       "Attempted to declare a parser with a gap in its positional arguments. No parser would interpret the argument at position 0 but there is a parser for at least one argument at a higher position."))
-    Attempted to declare a parser with a gap in its positional arguments. No parser would interpret the argument at position 0 but there is a parser for at least one argument at a higher position.----------------------------------------------------- Cmdliner
+    ----------------------------------------------------- Cmdliner
     Hello World
     ----------------------------------------------------- Core_command
     ("Translation Raised" (


### PR DESCRIPTION
### Changed

- Document presence in stdlib-runner help (required, default, etc.).
- Minor refactor in stdlib-runner.
- Upgrade to `climate.0.3.0`.

### Fixed

- Fix trailing dot additions in `to-cmdliner` for cases such as `?.` and `..`.
