### PR TITLE
Upgrade to climate.0.4.0 in tests

### DIFF
--- a/cmdlang-tests.opam
+++ b/cmdlang-tests.opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlformat" {with-dev-setup & = "0.27.0"}
   "base" {>= "v0.17" & < "v0.18"}
   "bisect_ppx" {with-dev-setup & >= "2.8.3"}
-  "climate" {>= "0.3.0"}
+  "climate" {>= "0.4.0"}
   "cmdlang" {= version}
   "cmdlang-stdlib-runner" {= version}
   "cmdlang-to-base" {= version}

--- a/dune-project
+++ b/dune-project
@@ -134,7 +134,7 @@
     (>= 2.8.3)))
   (climate
    (and
-    (>= 0.3.0)))
+    (>= 0.4.0)))
   (cmdlang
    (= :version))
   (cmdlang-stdlib-runner

--- a/lib/cmdlang_to_climate/test/test__param.ml
+++ b/lib/cmdlang_to_climate/test/test__param.ml
@@ -64,8 +64,8 @@ let%expect_test "enumerated" =
     |}];
   (match Stdlib.Format.printf "%a\n" conv.print Blue with
    | () -> assert false
-   | exception Climate.Spec_error.E e -> print_endline (Climate.Spec_error.to_string e));
+   | exception Failure e -> print_endline e);
   [%expect
-    {| Attempted to format an enum value as a string but the value does not appear in the enum declaration. Valid names for this enum are: red green |}];
+    {| Error in argument spec: Attempted to format an enum value as a string but the value does not appear in the enum declaration. Valid names for this enum are: red green |}];
   ()
 ;;

--- a/test/cram/basic.t
+++ b/test/cram/basic.t
@@ -21,7 +21,7 @@ String.
     <STRING>  value
   
   Options:
-    -h, --help  Print help
+    -h, --help  Show this help message.
 
   $ ./main_cmdliner.exe basic string --help=plain
   NAME
@@ -105,7 +105,7 @@ Int.
     <INT>  value
   
   Options:
-    -h, --help  Print help
+    -h, --help  Show this help message.
 
   $ ./main_cmdliner.exe basic int --help=plain
   NAME
@@ -226,7 +226,7 @@ Float.
     <FLOAT>  value
   
   Options:
-    -h, --help  Print help
+    -h, --help  Show this help message.
 
   $ ./main_cmdliner.exe basic float --help=plain
   NAME
@@ -347,7 +347,7 @@ Bool.
     <BOOL>  value
   
   Options:
-    -h, --help  Print help
+    -h, --help  Show this help message.
 
   $ ./main_cmdliner.exe basic bool --help=plain
   NAME
@@ -522,7 +522,7 @@ File.
     <FILE>  value
   
   Options:
-    -h, --help  Print help
+    -h, --help  Show this help message.
 
   $ ./main_cmdliner.exe basic file --help=plain
   NAME

--- a/test/cram/const.t
+++ b/test/cram/const.t
@@ -16,7 +16,7 @@ Checking the help when there are no arguments.
   Usage: ./main_climate.exe return [OPTIONS]
   
   Options:
-    -h, --help  Print help
+    -h, --help  Show this help message.
 
   $ ./main_cmdliner.exe return --help=plain
   NAME

--- a/test/cram/doc.t
+++ b/test/cram/doc.t
@@ -22,7 +22,7 @@
          ./main_climate.exe doc [OPTIONS]
   
   Options:
-    -h, --help  Print help
+    -h, --help  Show this help message.
   
   Commands:
     args-doc-end-with-dots  Args doc end with dots
@@ -116,7 +116,7 @@ A singleton command with a readme:
   Usage: ./main_climate.exe doc singleton-with-readme [OPTIONS]
   
   Options:
-    -h, --help  Print help
+    -h, --help  Show this help message.
 
   $ ./main_cmdliner.exe doc singleton-with-readme --help=plain
   NAME
@@ -195,7 +195,7 @@ integrates best with its formatting of help pages.
     <STRING>  The doc for [b] doesn't
   
   Options:
-    -h, --help  Print help
+    -h, --help  Show this help message.
 
   $ ./main_cmdliner.exe doc args-doc-end-with-dots --help=plain
   NAME

--- a/test/cram/enum.t
+++ b/test/cram/enum.t
@@ -64,7 +64,7 @@ Climate.
     <COLOR>  color
   
   Options:
-    -h, --help  Print help
+    -h, --help  Show this help message.
 
   $ ./main_climate.exe enum pos red
   red
@@ -79,8 +79,8 @@ Climate.
   Usage: ./main_climate.exe enum named [OPTIONS]
   
   Options:
+    -h, --help           Show this help message.
         --color <COLOR>  color
-    -h, --help           Print help
 
   $ ./main_climate.exe enum named --color red
   red

--- a/test/cram/flags.t
+++ b/test/cram/flags.t
@@ -18,9 +18,9 @@ Characterizing translation and behavior of various flag types.
   Usage: ./main_climate.exe flags names [OPTIONS]
   
   Options:
-    -a          short
+    -h, --help  Show this help message.
         --long  long
-    -h, --help  Print help
+    -a          short
 
   $ ./main_cmdliner.exe flags names --help=plain
   NAME

--- a/test/cram/group.t
+++ b/test/cram/group.t
@@ -22,7 +22,7 @@ Characterizing the help of a group:
          ./main_climate.exe basic [OPTIONS]
   
   Options:
-    -h, --help  Print help
+    -h, --help  Show this help message.
   
   Commands:
     string  print string
@@ -120,7 +120,7 @@ What happens when that group is run:
          ./main_climate.exe basic [OPTIONS]
   
   Options:
-    -h, --help  Print help
+    -h, --help  Show this help message.
   
   Commands:
     string  print string
@@ -175,7 +175,7 @@ Same with a group that has a default command:
     <STRING>  name
   
   Options:
-    -h, --help  Print help
+    -h, --help  Show this help message.
   
   Commands:
     a  do nothing

--- a/test/cram/main-help.t
+++ b/test/cram/main-help.t
@@ -26,7 +26,7 @@ the executable for each backend.
          ./main_climate.exe [OPTIONS]
   
   Options:
-    -h, --help  Print help
+    -h, --help  Show this help message.
   
   Commands:
     basic   Basic types

--- a/test/cram/named-opt.t
+++ b/test/cram/named-opt.t
@@ -19,8 +19,8 @@ Let's start with characterizing whether and how the default value appears in the
   Usage: ./main_climate.exe named opt string-with-docv [OPTIONS]
   
   Options:
+    -h, --help       Show this help message.
         --who <WHO>  Hello WHO?
-    -h, --help       Print help
 
   $ ./main_cmdliner.exe named opt string-with-docv --help=plain
   NAME
@@ -111,8 +111,8 @@ Characterizing the flag documentation when the `docv` parameter is not supplied.
   Usage: ./main_climate.exe named opt string-without-docv [OPTIONS]
   
   Options:
+    -h, --help          Show this help message.
         --who <STRING>  Hello WHO?
-    -h, --help          Print help
 
   $ ./main_cmdliner.exe named opt string-without-docv --help=plain
   NAME

--- a/test/cram/named-with-default.t
+++ b/test/cram/named-with-default.t
@@ -25,8 +25,8 @@ help page.
   Usage: ./main_climate.exe named with-default string [OPTIONS]
   
   Options:
+    -h, --help       Show this help message.
         --who <WHO>  Hello WHO?
-    -h, --help       Print help
 
 In the cmdliner backend, the default value is shown next to the option, in
 parentheses. See `(absent=...)` below.
@@ -237,8 +237,8 @@ functions or parsers generated from modules with utils.
   Usage: ./main_climate.exe named with-default create [OPTIONS]
   
   Options:
+    -h, --help         Show this help message.
         --who <(A|B)>  Greet A or B?
-    -h, --help         Print help
 
   $ ./main_cmdliner.exe named with-default create --help=plain
   NAME
@@ -306,8 +306,8 @@ Named-with-default with a stringable parameter.
   Usage: ./main_climate.exe named with-default stringable [OPTIONS]
   
   Options:
+    -h, --help       Show this help message.
         --who <VAL>  identifier
-    -h, --help       Print help
 
   $ ./main_cmdliner.exe named with-default stringable --help=plain
   NAME
@@ -389,8 +389,8 @@ Named-with-default with a validated string parameter.
   Usage: ./main_climate.exe named with-default validated [OPTIONS]
   
   Options:
+    -h, --help       Show this help message.
         --who <VAL>  4 letters alphanumerical identifier
-    -h, --help       Print help
 
   $ ./main_cmdliner.exe named with-default validated --help=plain
   NAME
@@ -523,8 +523,8 @@ Named-with-default with a comma-separated string parameter.
   Usage: ./main_climate.exe named with-default comma-separated [OPTIONS]
   
   Options:
+    -h, --help          Show this help message.
         --who <STRING>  Hello WHO?
-    -h, --help          Print help
 
   $ ./main_cmdliner.exe named with-default comma-separated --help=plain
   NAME

--- a/test/expect/arg_test.ml
+++ b/test/expect/arg_test.ml
@@ -54,13 +54,6 @@ let () =
       List [ Atom "Climate.Parse_error.E"; Atom (Climate.Parse_error.to_string e) ]
       [@coverage off]
     | _ -> assert false);
-  Sexplib0.Sexp_conv.Exn_converter.add
-    [%extension_constructor Climate.Spec_error.E]
-    (function
-    | Climate.Spec_error.E e ->
-      List [ Atom "Climate.Spec_error.E"; Atom (Climate.Spec_error.to_string e) ]
-      [@coverage off]
-    | _ -> assert false);
   ()
 ;;
 

--- a/test/expect/test__flag.ml
+++ b/test/expect/test__flag.ml
@@ -392,8 +392,8 @@ let%expect_test "user provided dashes" =
     {|
     ----------------------------------------------------- Climate
     ("Translation Raised" (
-      Climate.Spec_error.E
-      "Attempted to use \"-a\" as an argument name. \"-a\" is not a valid argument name because it begins with a dash which is not allowed."))
+      Failure
+      "Error in argument spec: Attempted to use \"-a\" as an argument name. \"-a\" is not a valid argument name because it begins with a dash which is not allowed."))
     ----------------------------------------------------- Cmdliner
     test: unknown option '-a'.
     Usage: test [---a] [OPTION]…
@@ -409,8 +409,8 @@ let%expect_test "user provided dashes" =
     {|
     ----------------------------------------------------- Climate
     ("Translation Raised" (
-      Climate.Spec_error.E
-      "Attempted to use \"--a\" as an argument name. \"--a\" is not a valid argument name because it begins with a dash which is not allowed."))
+      Failure
+      "Error in argument spec: Attempted to use \"--a\" as an argument name. \"--a\" is not a valid argument name because it begins with a dash which is not allowed."))
     ----------------------------------------------------- Cmdliner
     test: unknown option '--a', did you mean '----a'?
     Usage: test [----a] [OPTION]…
@@ -426,8 +426,8 @@ let%expect_test "user provided dashes" =
     {|
     ----------------------------------------------------- Climate
     ("Translation Raised" (
-      Climate.Spec_error.E
-      "Attempted to use \"-long\" as an argument name. \"-long\" is not a valid argument name because it begins with a dash which is not allowed."))
+      Failure
+      "Error in argument spec: Attempted to use \"-long\" as an argument name. \"-long\" is not a valid argument name because it begins with a dash which is not allowed."))
     ----------------------------------------------------- Cmdliner
     test: unknown option '-l', did you mean '---long'?
     Usage: test [---long] [OPTION]…
@@ -443,8 +443,8 @@ let%expect_test "user provided dashes" =
     {|
     ----------------------------------------------------- Climate
     ("Translation Raised" (
-      Climate.Spec_error.E
-      "Attempted to use \"--long\" as an argument name. \"--long\" is not a valid argument name because it begins with a dash which is not allowed."))
+      Failure
+      "Error in argument spec: Attempted to use \"--long\" as an argument name. \"--long\" is not a valid argument name because it begins with a dash which is not allowed."))
     ----------------------------------------------------- Cmdliner
     test: unknown option '--long', did you mean '----long'?
     Usage: test [----long] [OPTION]…

--- a/test/expect/test__help.ml
+++ b/test/expect/test__help.ml
@@ -10,11 +10,11 @@ let%expect_test "flag" =
   [%expect
     {|
     ----------------------------------------------------- Climate
-    [33;1mUsage: [0m[32;1mtest [OPTIONS][0m
+    [34;1mUsage: [0mtest [OPTIONS]
 
-    [33;1mOptions:[0m
-      [32;1m    --print-hello [0m print Hello
-      [32;1m-h, --help [0m        Print help
+    [34;1mOptions:[0m
+      [35;1m-h, --help[0m         Show this help message.
+      [35;1m    --print-hello[0m  print Hello
     ("Evaluation Raised" (Climate.Usage))
     ----------------------------------------------------- Cmdliner
     NAME

--- a/test/expect/test__pos.ml
+++ b/test/expect/test__pos.ml
@@ -56,8 +56,8 @@ let%expect_test "skipping-pos" =
     {|
     ----------------------------------------------------- Climate
     ("Evaluation Raised" (
-      Climate.Spec_error.E
-      "Attempted to declare a parser with a gap in its positional arguments. No parser would interpret the argument at position 0 but there is a parser for at least one argument at a higher position."))
+      Failure
+      "Error in argument spec: Attempted to declare a parser with a gap in its positional arguments. No parser would interpret the argument at position 0 but there is a parser for at least one argument at a higher position."))
     ----------------------------------------------------- Cmdliner
     test: required argument WHO is missing
     Usage: test [OPTION]… WHO
@@ -80,8 +80,8 @@ let%expect_test "skipping-pos" =
     {|
     ----------------------------------------------------- Climate
     ("Evaluation Raised" (
-      Climate.Spec_error.E
-      "Attempted to declare a parser with a gap in its positional arguments. No parser would interpret the argument at position 0 but there is a parser for at least one argument at a higher position."))
+      Failure
+      "Error in argument spec: Attempted to declare a parser with a gap in its positional arguments. No parser would interpret the argument at position 0 but there is a parser for at least one argument at a higher position."))
     ----------------------------------------------------- Cmdliner
     test: required argument WHO is missing
     Usage: test [OPTION]… WHO
@@ -104,8 +104,8 @@ let%expect_test "skipping-pos" =
     {|
     ----------------------------------------------------- Climate
     ("Evaluation Raised" (
-      Climate.Spec_error.E
-      "Attempted to declare a parser with a gap in its positional arguments. No parser would interpret the argument at position 0 but there is a parser for at least one argument at a higher position."))
+      Failure
+      "Error in argument spec: Attempted to declare a parser with a gap in its positional arguments. No parser would interpret the argument at position 0 but there is a parser for at least one argument at a higher position."))
     ----------------------------------------------------- Cmdliner
     Hello World
     ----------------------------------------------------- Core_command


### PR DESCRIPTION
The rest of the packages did not necessitate changes to go from climate 0.3.0 to 0.4.0, thus I am not bumping the required version for them at this time.

Changes:
- Error exception using now Failure;
- Formatting changes in help messages.