### PR TITLE
Upgrade climate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,17 @@
+## 0.0.10 (unreleased)
+
+### Added
+
+### Changed
+
+- Upgrade `climate` and now requires `>= 0.5.0` (@mbarbin).
+
+### Deprecated
+
+### Fixed
+
+### Removed
+
 ## 0.0.9 (2024-11-30)
 
 ### Added

--- a/cmdlang-tests.opam
+++ b/cmdlang-tests.opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlformat" {with-dev-setup & = "0.27.0"}
   "base" {>= "v0.17" & < "v0.18"}
   "bisect_ppx" {with-dev-setup & >= "2.8.3"}
-  "climate" {>= "0.4.0" & < "0.5.0"}
+  "climate" {>= "0.5.0"}
   "cmdlang" {= version}
   "cmdlang-stdlib-runner" {= version}
   "cmdlang-to-base" {= version}

--- a/cmdlang-to-climate.opam
+++ b/cmdlang-to-climate.opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/mbarbin/cmdlang/issues"
 depends: [
   "dune" {>= "3.17"}
   "ocaml" {>= "4.14"}
-  "climate" {>= "0.3.0" & < "0.5.0"}
+  "climate" {>= "0.5.0"}
   "cmdlang" {= version}
   "odoc" {with-doc}
 ]

--- a/dune-project
+++ b/dune-project
@@ -100,9 +100,7 @@
   (ocaml
    (>= 4.14))
   (climate
-   (and
-    (>= 0.3.0)
-    (< 0.5.0)))
+   (>= 0.5.0))
   (cmdlang
    (= :version))))
 
@@ -134,9 +132,7 @@
     :with-dev-setup
     (>= 2.8.3)))
   (climate
-   (and
-    (>= 0.4.0)
-    (< 0.5.0)))
+   (>= 0.5.0))
   (cmdlang
    (= :version))
   (cmdlang-stdlib-runner

--- a/dune-project
+++ b/dune-project
@@ -90,8 +90,7 @@
   (cmdlang
    (= :version))
   (cmdliner
-   (and
-    (>= 1.3.0)))))
+   (>= 1.3.0))))
 
 (package
  (name cmdlang-to-climate)

--- a/lib/cmdlang_to_climate/src/translate.ml
+++ b/lib/cmdlang_to_climate/src/translate.ml
@@ -51,7 +51,7 @@ end
 module Arg = struct
   let fmt_doc ~doc = doc
 
-  let make_desc : type a. doc:string -> param:a Ast.Param.t -> string =
+  let make_doc : type a. doc:string -> param:a Ast.Param.t -> string =
     fun ~doc ~param ->
     match (param : _ Ast.Param.t) with
     | Conv _ | String | Int | Float | Bool | File
@@ -65,62 +65,62 @@ module Arg = struct
     | Both (a, b) -> Climate.Arg_parser.both (translate a) (translate b)
     | Apply { f; x } -> Climate.Arg_parser.apply (translate f) (translate x)
     | Flag { names = hd :: tl; doc } ->
-      let desc = fmt_doc ~doc in
-      Climate.Arg_parser.flag ~desc (hd :: tl)
+      let doc = fmt_doc ~doc in
+      Climate.Arg_parser.flag ~doc (hd :: tl)
     | Flag_count { names = hd :: tl; doc } ->
-      let desc = fmt_doc ~doc in
-      Climate.Arg_parser.flag_count ~desc (hd :: tl)
+      let doc = fmt_doc ~doc in
+      Climate.Arg_parser.flag_count ~doc (hd :: tl)
     | Named { names = hd :: tl; param; docv; doc } ->
-      let desc = make_desc ~doc ~param in
+      let doc = make_doc ~doc ~param in
       Climate.Arg_parser.named_req
-        ~desc
+        ~doc
         ?value_name:docv
         (hd :: tl)
         (param |> Param.translate)
     | Named_multi { names = hd :: tl; param; docv; doc } ->
-      let desc = make_desc ~doc ~param in
+      let doc = make_doc ~doc ~param in
       Climate.Arg_parser.named_multi
-        ~desc
+        ~doc
         ?value_name:docv
         (hd :: tl)
         (param |> Param.translate)
     | Named_opt { names = hd :: tl; param; docv; doc } ->
-      let desc = make_desc ~doc ~param in
+      let doc = make_doc ~doc ~param in
       Climate.Arg_parser.named_opt
-        ~desc
+        ~doc
         ?value_name:docv
         (hd :: tl)
         (param |> Param.translate)
     | Named_with_default { names = hd :: tl; param; default; docv; doc } ->
-      let desc = make_desc ~doc ~param in
+      let doc = make_doc ~doc ~param in
       Climate.Arg_parser.named_with_default
-        ~desc
+        ~doc
         ?value_name:docv
         (hd :: tl)
         (param |> Param.translate)
         ~default
     | Pos { pos; param; docv; doc } ->
-      let desc = make_desc ~doc ~param in
-      Climate.Arg_parser.pos_req ~desc ?value_name:docv pos (param |> Param.translate)
+      let doc = make_doc ~doc ~param in
+      Climate.Arg_parser.pos_req ~doc ?value_name:docv pos (param |> Param.translate)
     | Pos_opt { pos; param; docv; doc } ->
-      let desc = make_desc ~doc ~param in
-      Climate.Arg_parser.pos_opt ~desc ?value_name:docv pos (param |> Param.translate)
+      let doc = make_doc ~doc ~param in
+      Climate.Arg_parser.pos_opt ~doc ?value_name:docv pos (param |> Param.translate)
     | Pos_with_default { pos; param; default; docv; doc } ->
-      let desc = make_desc ~doc ~param in
+      let doc = make_doc ~doc ~param in
       Climate.Arg_parser.pos_with_default
-        ~desc
+        ~doc
         ?value_name:docv
         pos
         (param |> Param.translate)
         ~default
     | Pos_all { param; docv; doc } ->
-      let desc = make_desc ~doc ~param in
-      Climate.Arg_parser.pos_all ~desc ?value_name:docv (param |> Param.translate)
+      let doc = make_doc ~doc ~param in
+      Climate.Arg_parser.pos_all ~doc ?value_name:docv (param |> Param.translate)
   ;;
 end
 
 module Command = struct
-  let desc ~summary ~readme =
+  let doc ~summary ~readme =
     match readme with
     | None -> summary
     | Some readme -> summary ^ "\n" ^ readme ()
@@ -130,12 +130,12 @@ module Command = struct
     fun command ->
     match command with
     | Make { arg; summary; readme } ->
-      Climate.Command.singleton ~desc:(desc ~summary ~readme) (arg |> Arg.translate)
+      Climate.Command.singleton ~doc:(doc ~summary ~readme) (arg |> Arg.translate)
     | Group { default; summary; readme; subcommands } ->
       let cmds = subcommands |> List.map (fun (name, arg) -> to_subcommand arg ~name) in
       Climate.Command.group
         ?default_arg_parser:(default |> Option.map Arg.translate)
-        ~desc:(desc ~summary ~readme)
+        ~doc:(doc ~summary ~readme)
         cmds
 
   and to_subcommand

--- a/test/cram/basic.t
+++ b/test/cram/basic.t
@@ -15,7 +15,7 @@ String.
   $ ./main_climate.exe basic string --help
   print string
   
-  Usage: ./main_climate.exe basic string [OPTIONS] <STRING>
+  Usage: ./main_climate.exe basic string [OPTION]… <STRING>
   
   Arguments:
     <STRING>  value
@@ -99,7 +99,7 @@ Int.
   $ ./main_climate.exe basic int --help
   print int
   
-  Usage: ./main_climate.exe basic int [OPTIONS] <INT>
+  Usage: ./main_climate.exe basic int [OPTION]… <INT>
   
   Arguments:
     <INT>  value
@@ -220,7 +220,7 @@ Float.
   $ ./main_climate.exe basic float --help
   print float
   
-  Usage: ./main_climate.exe basic float [OPTIONS] <FLOAT>
+  Usage: ./main_climate.exe basic float [OPTION]… <FLOAT>
   
   Arguments:
     <FLOAT>  value
@@ -341,7 +341,7 @@ Bool.
   $ ./main_climate.exe basic bool --help
   print bool
   
-  Usage: ./main_climate.exe basic bool [OPTIONS] <BOOL>
+  Usage: ./main_climate.exe basic bool [OPTION]… <BOOL>
   
   Arguments:
     <BOOL>  value
@@ -516,7 +516,7 @@ File.
   $ ./main_climate.exe basic file --help
   print file
   
-  Usage: ./main_climate.exe basic file [OPTIONS] <FILE>
+  Usage: ./main_climate.exe basic file [OPTION]… <FILE>
   
   Arguments:
     <FILE>  value

--- a/test/cram/const.t
+++ b/test/cram/const.t
@@ -13,7 +13,7 @@ Checking the help when there are no arguments.
   $ ./main_climate.exe return --help
   An empty command
   
-  Usage: ./main_climate.exe return [OPTIONS]
+  Usage: ./main_climate.exe return [OPTION]…
   
   Options:
     -h, --help  Show this help message.

--- a/test/cram/doc.t
+++ b/test/cram/doc.t
@@ -19,7 +19,7 @@
       
   
   Usage: ./main_climate.exe doc [COMMAND]
-         ./main_climate.exe doc [OPTIONS]
+         ./main_climate.exe doc [OPTION]…
   
   Options:
     -h, --help  Show this help message.
@@ -113,7 +113,7 @@ A singleton command with a readme:
   It can be written on multiple lines.
   
   
-  Usage: ./main_climate.exe doc singleton-with-readme [OPTIONS]
+  Usage: ./main_climate.exe doc singleton-with-readme [OPTION]…
   
   Options:
     -h, --help  Show this help message.
@@ -188,7 +188,7 @@ integrates best with its formatting of help pages.
   $ ./main_climate.exe doc args-doc-end-with-dots --help
   Args doc end with dots
   
-  Usage: ./main_climate.exe doc args-doc-end-with-dots [OPTIONS] <STRING> <STRING>
+  Usage: ./main_climate.exe doc args-doc-end-with-dots [OPTION]… <STRING> <STRING>
   
   Arguments:
     <STRING>  The doc for [a] in the code ends with a dot.

--- a/test/cram/enum.t
+++ b/test/cram/enum.t
@@ -58,7 +58,7 @@ Climate.
   $ ./main_climate.exe enum pos --help
   print color
   
-  Usage: ./main_climate.exe enum pos [OPTIONS] <COLOR>
+  Usage: ./main_climate.exe enum pos [OPTION]… <COLOR>
   
   Arguments:
     <COLOR>  color
@@ -76,11 +76,11 @@ Climate.
   $ ./main_climate.exe enum named --help
   print color
   
-  Usage: ./main_climate.exe enum named [OPTIONS]
+  Usage: ./main_climate.exe enum named [OPTION]…
   
   Options:
-    -h, --help           Show this help message.
         --color <COLOR>  color
+    -h, --help           Show this help message.
 
   $ ./main_climate.exe enum named --color red
   red

--- a/test/cram/flags.t
+++ b/test/cram/flags.t
@@ -15,12 +15,12 @@ Characterizing translation and behavior of various flag types.
   $ ./main_climate.exe flags names --help
   various flags
   
-  Usage: ./main_climate.exe flags names [OPTIONS]
+  Usage: ./main_climate.exe flags names [OPTION]…
   
   Options:
-    -h, --help  Show this help message.
-        --long  long
     -a          short
+        --long  long
+    -h, --help  Show this help message.
 
   $ ./main_cmdliner.exe flags names --help=plain
   NAME

--- a/test/cram/group.t
+++ b/test/cram/group.t
@@ -19,7 +19,7 @@ Characterizing the help of a group:
   Basic types
   
   Usage: ./main_climate.exe basic [COMMAND]
-         ./main_climate.exe basic [OPTIONS]
+         ./main_climate.exe basic [OPTION]…
   
   Options:
     -h, --help  Show this help message.
@@ -117,7 +117,7 @@ What happens when that group is run:
   Basic types
   
   Usage: ./main_climate.exe basic [COMMAND]
-         ./main_climate.exe basic [OPTIONS]
+         ./main_climate.exe basic [OPTION]…
   
   Options:
     -h, --help  Show this help message.
@@ -169,7 +169,7 @@ Same with a group that has a default command:
   A group command with a default
   
   Usage: ./main_climate.exe group [COMMAND]
-         ./main_climate.exe group [OPTIONS] <STRING>
+         ./main_climate.exe group [OPTION]… <STRING>
   
   Arguments:
     <STRING>  name

--- a/test/cram/main-help.t
+++ b/test/cram/main-help.t
@@ -23,7 +23,7 @@ the executable for each backend.
   Cram Test Command
   
   Usage: ./main_climate.exe [COMMAND]
-         ./main_climate.exe [OPTIONS]
+         ./main_climate.exe [OPTION]…
   
   Options:
     -h, --help  Show this help message.

--- a/test/cram/named-opt.t
+++ b/test/cram/named-opt.t
@@ -16,11 +16,11 @@ Let's start with characterizing whether and how the default value appears in the
   $ ./main_climate.exe named opt string-with-docv --help
   Named_opt__string_with_docv
   
-  Usage: ./main_climate.exe named opt string-with-docv [OPTIONS]
+  Usage: ./main_climate.exe named opt string-with-docv [OPTION]…
   
   Options:
-    -h, --help       Show this help message.
         --who <WHO>  Hello WHO?
+    -h, --help       Show this help message.
 
   $ ./main_cmdliner.exe named opt string-with-docv --help=plain
   NAME
@@ -108,11 +108,11 @@ Characterizing the flag documentation when the `docv` parameter is not supplied.
   $ ./main_climate.exe named opt string-without-docv --help
   Named_opt__string_without_docv
   
-  Usage: ./main_climate.exe named opt string-without-docv [OPTIONS]
+  Usage: ./main_climate.exe named opt string-without-docv [OPTION]…
   
   Options:
-    -h, --help          Show this help message.
         --who <STRING>  Hello WHO?
+    -h, --help          Show this help message.
 
   $ ./main_cmdliner.exe named opt string-without-docv --help=plain
   NAME

--- a/test/cram/named-with-default.t
+++ b/test/cram/named-with-default.t
@@ -22,11 +22,11 @@ help page.
   $ ./main_climate.exe named with-default string --help
   Named_with_default__string
   
-  Usage: ./main_climate.exe named with-default string [OPTIONS]
+  Usage: ./main_climate.exe named with-default string [OPTION]…
   
   Options:
-    -h, --help       Show this help message.
         --who <WHO>  Hello WHO?
+    -h, --help       Show this help message.
 
 In the cmdliner backend, the default value is shown next to the option, in
 parentheses. See `(absent=...)` below.
@@ -234,11 +234,11 @@ functions or parsers generated from modules with utils.
   $ ./main_climate.exe named with-default create --help
   Named_with_default__create
   
-  Usage: ./main_climate.exe named with-default create [OPTIONS]
+  Usage: ./main_climate.exe named with-default create [OPTION]…
   
   Options:
-    -h, --help         Show this help message.
         --who <(A|B)>  Greet A or B?
+    -h, --help         Show this help message.
 
   $ ./main_cmdliner.exe named with-default create --help=plain
   NAME
@@ -303,11 +303,11 @@ Named-with-default with a stringable parameter.
   $ ./main_climate.exe named with-default stringable --help
   Named_with_default__stringable
   
-  Usage: ./main_climate.exe named with-default stringable [OPTIONS]
+  Usage: ./main_climate.exe named with-default stringable [OPTION]…
   
   Options:
-    -h, --help       Show this help message.
         --who <VAL>  identifier
+    -h, --help       Show this help message.
 
   $ ./main_cmdliner.exe named with-default stringable --help=plain
   NAME
@@ -386,11 +386,11 @@ Named-with-default with a validated string parameter.
   $ ./main_climate.exe named with-default validated --help
   Named_with_default__validated
   
-  Usage: ./main_climate.exe named with-default validated [OPTIONS]
+  Usage: ./main_climate.exe named with-default validated [OPTION]…
   
   Options:
-    -h, --help       Show this help message.
         --who <VAL>  4 letters alphanumerical identifier
+    -h, --help       Show this help message.
 
   $ ./main_cmdliner.exe named with-default validated --help=plain
   NAME
@@ -520,11 +520,11 @@ Named-with-default with a comma-separated string parameter.
   $ ./main_climate.exe named with-default comma-separated --help
   Named_with_default__comma_separated
   
-  Usage: ./main_climate.exe named with-default comma-separated [OPTIONS]
+  Usage: ./main_climate.exe named with-default comma-separated [OPTION]…
   
   Options:
-    -h, --help          Show this help message.
         --who <STRING>  Hello WHO?
+    -h, --help          Show this help message.
 
   $ ./main_cmdliner.exe named with-default comma-separated --help=plain
   NAME

--- a/test/expect/climate_non_ret.ml
+++ b/test/expect/climate_non_ret.ml
@@ -1,0 +1,12 @@
+type t = Climate.For_test.Non_ret.t
+
+let print : t -> unit = function
+  | Help spec -> Climate.For_test.print_help_spec spec
+  | Manpage { spec; prose } -> Climate.For_test.print_manpage spec prose
+  | Reentrant_query { suggestions } ->
+    print_s [%sexp Reentrant_query { suggestions : string list }]
+  | Parse_error parse_error ->
+    print_endline (Climate.For_test.Parse_error.to_string parse_error)
+  | Generate_completion_script { completion_script } ->
+    print_s [%sexp Generate_completion_script { completion_script : string }]
+;;

--- a/test/expect/climate_non_ret.ml
+++ b/test/expect/climate_non_ret.ml
@@ -2,11 +2,12 @@ type t = Climate.For_test.Non_ret.t
 
 let print : t -> unit = function
   | Help spec -> Climate.For_test.print_help_spec spec
-  | Manpage { spec; prose } -> Climate.For_test.print_manpage spec prose
+  | Manpage { spec; prose } -> Climate.For_test.print_manpage spec prose [@coverage off]
   | Reentrant_query { suggestions } ->
-    print_s [%sexp Reentrant_query { suggestions : string list }]
+    print_s [%sexp Reentrant_query { suggestions : string list }] [@coverage off]
   | Parse_error parse_error ->
     print_endline (Climate.For_test.Parse_error.to_string parse_error)
   | Generate_completion_script { completion_script } ->
-    print_s [%sexp Generate_completion_script { completion_script : string }]
+    print_s
+      [%sexp Generate_completion_script { completion_script : string }] [@coverage off]
 ;;

--- a/test/expect/climate_non_ret.mli
+++ b/test/expect/climate_non_ret.mli
@@ -1,0 +1,5 @@
+(** This is a helper that allows printing climate errors in the expect tests. *)
+
+type t = Climate.For_test.Non_ret.t
+
+val print : t -> unit

--- a/test/expect/test__flag.ml
+++ b/test/expect/test__flag.ml
@@ -33,7 +33,7 @@ let%expect_test "flag" =
   [%expect
     {|
     ----------------------------------------------------- Climate
-    ("Evaluation Raised" (Climate.Parse_error.E "Unknown argument name: -p"))
+    Evaluation Failed: Unknown argument name: -p
     ----------------------------------------------------- Cmdliner
     test: unknown option '-p'.
     Usage: test [--print-hello] [OPTION]…
@@ -62,7 +62,7 @@ let%expect_test "flag" =
   [%expect
     {|
     ----------------------------------------------------- Climate
-    ("Evaluation Raised" (Climate.Parse_error.E "Unknown argument name: -p"))
+    Evaluation Failed: Unknown argument name: -p
     ----------------------------------------------------- Cmdliner
     test: unknown option '-p', did you mean '--print-hello'?
     Usage: test [--print-hello] [OPTION]…
@@ -90,7 +90,7 @@ let%expect_test "flag" =
   [%expect
     {|
     ----------------------------------------------------- Climate
-    ("Evaluation Raised" (Climate.Parse_error.E "Unknown argument name: --print"))
+    Evaluation Failed: Unknown argument name: --print
     ----------------------------------------------------- Cmdliner
     Hello
     ----------------------------------------------------- Core_command
@@ -143,9 +143,7 @@ let%expect_test "1-letter-flag" =
   [%expect
     {|
     ----------------------------------------------------- Climate
-    ("Evaluation Raised" (
-      Climate.Parse_error.E
-      "Single-character names must only be specified with a single dash. \"--p\" is not allowed as it has two dashes but only one character."))
+    Evaluation Failed: Single-character names must only be specified with a single dash. "--p" is not allowed as it has two dashes but only one character.
     ----------------------------------------------------- Cmdliner
     test: unknown option '--p', did you mean '-p'?
     Usage: test [-p] [OPTION]…
@@ -219,9 +217,7 @@ let%expect_test "1-letter-alias" =
   [%expect
     {|
     ----------------------------------------------------- Climate
-    ("Evaluation Raised" (
-      Climate.Parse_error.E
-      "Single-character names must only be specified with a single dash. \"--p\" is not allowed as it has two dashes but only one character."))
+    Evaluation Failed: Single-character names must only be specified with a single dash. "--p" is not allowed as it has two dashes but only one character.
     ----------------------------------------------------- Cmdliner
     Hello
     ----------------------------------------------------- Core_command
@@ -291,8 +287,7 @@ let%expect_test "ambiguous prefixes" =
   [%expect
     {|
     ----------------------------------------------------- Climate
-    ("Evaluation Raised" (
-      Climate.Parse_error.E "Unknown argument name: --print-hello-w"))
+    Evaluation Failed: Unknown argument name: --print-hello-w
     ----------------------------------------------------- Cmdliner
     Hello World
     ----------------------------------------------------- Core_command
@@ -315,8 +310,7 @@ let%expect_test "ambiguous prefixes" =
   [%expect
     {|
     ----------------------------------------------------- Climate
-    ("Evaluation Raised" (
-      Climate.Parse_error.E "Unknown argument name: --print-hello"))
+    Evaluation Failed: Unknown argument name: --print-hello
     ----------------------------------------------------- Cmdliner
     test: option '--print-hello' ambiguous and could be either '--print-hello-world' or '--print-hello-you'
     Usage: test [--print-hello-world] [--print-hello-you] [OPTION]…

--- a/test/expect/test__help.ml
+++ b/test/expect/test__help.ml
@@ -10,12 +10,11 @@ let%expect_test "flag" =
   [%expect
     {|
     ----------------------------------------------------- Climate
-    [34;1mUsage: [0mtest [OPTIONS]
+    Evaluation Failed: Usage: test [OPTION]…
 
-    [34;1mOptions:[0m
-      [35;1m-h, --help[0m         Show this help message.
-      [35;1m    --print-hello[0m  print Hello
-    ("Evaluation Raised" (Climate.Usage))
+    Options:
+          --print-hello  print Hello
+      -h, --help         Show this help message.
     ----------------------------------------------------- Cmdliner
     NAME
            test

--- a/test/expect/test__invalid_pos_opt.ml
+++ b/test/expect/test__invalid_pos_opt.ml
@@ -27,8 +27,7 @@ let%expect_test "invalid_pos_sequence" =
   [%expect
     {|
     ----------------------------------------------------- Climate
-    ("Evaluation Raised" (
-      Climate.Parse_error.E "Missing required positional argument at position 1."))
+    Evaluation Failed: Missing required positional argument at position 1.
     ----------------------------------------------------- Cmdliner
     test: required argument STRING is missing
     Usage: test [OPTION]… [STRING] STRING
@@ -62,18 +61,17 @@ let%expect_test "base" =
 let%expect_test "climate" =
   let cmd = Cmdlang_to_climate.Translate.command cmd in
   let run args =
-    match Climate.Command.eval cmd ~program_name:(Literal "./main.exe") args with
-    | () -> ()
-    | exception e -> print_s [%sexp "Evaluation raised", (e : Exn.t)]
+    match Climate.For_test.eval_result ~program_name:"./main.exe" cmd args with
+    | Ok () -> ()
+    | Error e ->
+      print_string "Evaluation Failed: ";
+      Climate_non_ret.print e
+    | exception e -> print_s [%sexp "Evaluation Raised", (e : Exn.t)] [@coverage off]
   in
   run [ "A"; "B" ];
   [%expect {| ((a (A)) (b B)) |}];
   run [ "B" ];
-  [%expect
-    {|
-    ("Evaluation raised" (
-      Climate.Parse_error.E "Missing required positional argument at position 1."))
-    |}];
+  [%expect {| Evaluation Failed: Missing required positional argument at position 1. |}];
   ()
 ;;
 

--- a/test/expect/test__named.ml
+++ b/test/expect/test__named.ml
@@ -12,8 +12,7 @@ let%expect_test "named" =
   [%expect
     {|
     ----------------------------------------------------- Climate
-    ("Evaluation Raised" (
-      Climate.Parse_error.E "Missing required named argument: --who"))
+    Evaluation Failed: Missing required named argument: --who
     ----------------------------------------------------- Cmdliner
     test: required option --who is missing
     Usage: test [--who=WHO] [OPTION]…
@@ -67,8 +66,7 @@ let%expect_test "1-letter-named" =
   [%expect
     {|
     ----------------------------------------------------- Climate
-    ("Evaluation Raised" (
-      Climate.Parse_error.E "Missing required named argument: -w"))
+    Evaluation Failed: Missing required named argument: -w
     ----------------------------------------------------- Cmdliner
     test: required option -w is missing
     Usage: test [-w WHO] [OPTION]…

--- a/test/expect/test__negative_int_args.ml
+++ b/test/expect/test__negative_int_args.ml
@@ -43,7 +43,7 @@ let%expect_test "negative positional" =
   [%expect
     {|
     ----------------------------------------------------- Climate
-    ("Evaluation Raised" (Climate.Parse_error.E "Unknown argument name: -1"))
+    Evaluation Failed: Unknown argument name: -1
     ----------------------------------------------------- Cmdliner
     test: unknown option '-1'.
     Usage: test [OPTION]… INT

--- a/test/expect/test__param.ml
+++ b/test/expect/test__param.ml
@@ -41,9 +41,7 @@ let%expect_test "int" =
   [%expect
     {|
     ----------------------------------------------------- Climate
-    ("Evaluation Raised" (
-      Climate.Parse_error.E
-      "Failed to parse the argument at position 0: invalid value: \"not-an-int\" (not an int)"))
+    Evaluation Failed: Failed to parse the argument at position 0: invalid value: "not-an-int" (not an int)
     ----------------------------------------------------- Cmdliner
     test: INT argument: invalid value 'not-an-int', expected an integer
     Usage: test [OPTION]… INT
@@ -99,9 +97,7 @@ let%expect_test "float" =
   [%expect
     {|
     ----------------------------------------------------- Climate
-    ("Evaluation Raised" (
-      Climate.Parse_error.E
-      "Failed to parse the argument at position 0: invalid value: \"not-an-number\" (not an float)"))
+    Evaluation Failed: Failed to parse the argument at position 0: invalid value: "not-an-number" (not an float)
     ----------------------------------------------------- Cmdliner
     test: FLOAT argument: invalid value 'not-an-number', expected a floating
           point number
@@ -158,9 +154,7 @@ let%expect_test "bool" =
   [%expect
     {|
     ----------------------------------------------------- Climate
-    ("Evaluation Raised" (
-      Climate.Parse_error.E
-      "Failed to parse the argument at position 0: invalid value: \"not-a-bool\" (not an bool)"))
+    Evaluation Failed: Failed to parse the argument at position 0: invalid value: "not-a-bool" (not an bool)
     ----------------------------------------------------- Cmdliner
     test: BOOL argument: invalid value 'not-a-bool', either 'true' or 'false'
     Usage: test [OPTION]… BOOL
@@ -266,9 +260,7 @@ let%expect_test "enumerated" =
   [%expect
     {|
     ----------------------------------------------------- Climate
-    ("Evaluation Raised" (
-      Climate.Parse_error.E
-      "Failed to parse the argument at position 0: invalid value: \"Not_an_e\" (valid values are: A, B)"))
+    Evaluation Failed: Failed to parse the argument at position 0: invalid value: "Not_an_e" (valid values are: A, B)
     ----------------------------------------------------- Cmdliner
     test: invalid value 'Not_an_e', expected either 'A' or 'B'
     Usage: test [OPTION]… ARG
@@ -385,9 +377,7 @@ let%expect_test "validated_string" =
   [%expect
     {|
     ----------------------------------------------------- Climate
-    ("Evaluation Raised" (
-      Climate.Parse_error.E
-      "Failed to parse the argument at position 0: invalid id"))
+    Evaluation Failed: Failed to parse the argument at position 0: invalid id
     ----------------------------------------------------- Cmdliner
     test: invalid id
     Usage: test [OPTION]… ARG
@@ -474,9 +464,7 @@ let%expect_test "comma_separated" =
   [%expect
     {|
     ----------------------------------------------------- Climate
-    ("Evaluation Raised" (
-      Climate.Parse_error.E
-      "Failed to parse the argument at position 0: invalid value: \"\" (valid values are: A, B)"))
+    Evaluation Failed: Failed to parse the argument at position 0: invalid value: "" (valid values are: A, B)
     ----------------------------------------------------- Cmdliner
 
     ----------------------------------------------------- Core_command
@@ -500,9 +488,7 @@ let%expect_test "comma_separated" =
   [%expect
     {|
     ----------------------------------------------------- Climate
-    ("Evaluation Raised" (
-      Climate.Parse_error.E
-      "Failed to parse the argument at position 0: invalid value: \"Not_an_e\" (valid values are: A, B)"))
+    Evaluation Failed: Failed to parse the argument at position 0: invalid value: "Not_an_e" (valid values are: A, B)
     ----------------------------------------------------- Cmdliner
     test: invalid element in list ('Not_an_e'): invalid value 'Not_an_e',
           expected either 'A' or 'B'

--- a/test/expect/test__pos.ml
+++ b/test/expect/test__pos.ml
@@ -12,8 +12,7 @@ let%expect_test "pos" =
   [%expect
     {|
     ----------------------------------------------------- Climate
-    ("Evaluation Raised" (
-      Climate.Parse_error.E "Missing required positional argument at position 0."))
+    Evaluation Failed: Missing required positional argument at position 0.
     ----------------------------------------------------- Cmdliner
     test: required argument WHO is missing
     Usage: test [OPTION]… WHO


### PR DESCRIPTION
Upgrade to newly released `climate.0.5.0`.

This only goes through the required changes to build `cmdlang` however we do not make use yet of the new features offered by `climate`, namely auto-completion or man pages generation (this is left as future work).