### PR TITLE
OCaml 5.4 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         os:
           - ubuntu-latest
         ocaml-compiler:
-          - 5.3.x
+          - 5.4.x
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           opam-repositories: |
             default: https://github.com/ocaml/opam-repository.git
             mbarbin: https://github.com/mbarbin/opam-repository.git
-      #     alpha:   https://github.com/kit-ty-kate/opam-alpha-repository.git
+            alpha:   https://github.com/kit-ty-kate/opam-alpha-repository.git
       #     janestreet-bleeding: https://github.com/janestreet/opam-repository.git
       #     janestreet-bleeding-external: https://github.com/janestreet/opam-repository.git#external-packages
 

--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: "5.3.x"
+          ocaml-compiler: "5.4.x"
           dune-cache: true
           opam-repositories: |
             default: https://github.com/ocaml/opam-repository.git

--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -39,7 +39,7 @@ jobs:
           opam-repositories: |
             default: https://github.com/ocaml/opam-repository.git
             mbarbin: https://github.com/mbarbin/opam-repository.git
-      #     alpha:   https://github.com/kit-ty-kate/opam-alpha-repository.git
+            alpha:   https://github.com/kit-ty-kate/opam-alpha-repository.git
       #     janestreet-bleeding: https://github.com/janestreet/opam-repository.git
       #     janestreet-bleeding-external: https://github.com/janestreet/opam-repository.git#external-packages
 

--- a/.github/workflows/more-ci.yml
+++ b/.github/workflows/more-ci.yml
@@ -29,13 +29,14 @@ jobs:
           - ubuntu-latest
           - windows-latest
         ocaml-compiler:
+          - 5.4.x
           - 5.3.x
           - 5.2.x
           - 4.14.x
         exclude:
           # We exclude the combination already tested in the 'ci' workflow.
           - os: ubuntu-latest
-            ocaml-compiler: 5.3.x
+            ocaml-compiler: 5.4.x
           # We exclude windows-4.14 - this fails when building core.
           - os: windows-latest
             ocaml-compiler: 4.14.x

--- a/.github/workflows/test-deploy-doc.yml
+++ b/.github/workflows/test-deploy-doc.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: "5.3.x"
+          ocaml-compiler: "5.4.x"
           dune-cache: true
           opam-repositories: |
             default: https://github.com/ocaml/opam-repository.git

--- a/.github/workflows/test-deploy-doc.yml
+++ b/.github/workflows/test-deploy-doc.yml
@@ -39,7 +39,7 @@ jobs:
           opam-repositories: |
             default: https://github.com/ocaml/opam-repository.git
             mbarbin: https://github.com/mbarbin/opam-repository.git
-      #     alpha:   https://github.com/kit-ty-kate/opam-alpha-repository.git
+            alpha:   https://github.com/kit-ty-kate/opam-alpha-repository.git
       #     janestreet-bleeding: https://github.com/janestreet/opam-repository.git
       #     janestreet-bleeding-external: https://github.com/janestreet/opam-repository.git#external-packages
 

--- a/cmdlang-dev.opam
+++ b/cmdlang-dev.opam
@@ -9,7 +9,7 @@ doc: "https://mbarbin.github.io/cmdlang/"
 bug-reports: "https://github.com/mbarbin/cmdlang/issues"
 depends: [
   "dune" {>= "3.17"}
-  "ocaml" {>= "5.2"}
+  "ocaml" {>= "5.4"}
   "ocamlformat" {= "0.28.1"}
   "base" {>= "v0.17"}
   "bisect_ppx" {>= "2.8.3"}

--- a/cmdlang-tests.opam
+++ b/cmdlang-tests.opam
@@ -9,7 +9,7 @@ doc: "https://mbarbin.github.io/cmdlang/"
 bug-reports: "https://github.com/mbarbin/cmdlang/issues"
 depends: [
   "dune" {>= "3.17"}
-  "ocaml" {>= "5.2"}
+  "ocaml" {>= "5.4"}
   "base" {>= "v0.17"}
   "climate" {>= "0.8.5"}
   "cmdlang" {= version}

--- a/doc/docs/guides/usage-styles/lib/dune
+++ b/doc/docs/guides/usage-styles/lib/dune
@@ -4,7 +4,13 @@
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a -open Cmdlang)
  (libraries cmdlang)
  (lint
-  (pps ppx_js_style -allow-let-operators -check-doc-comments))
+  (pps
+   ppx_js_style
+   -allow-let-operators
+   -check-doc-comments
+   ;; A workaround an issue with this particular lint in that repo with OCaml 5.4
+   ;; See also [https://github.com/janestreet/ppx_js_style/issues/4].
+   -allow-unannotated-ignores))
  (preprocess
   (pps
    -unused-code-warnings=force

--- a/dune-project
+++ b/dune-project
@@ -99,7 +99,7 @@
  (synopsis "Tests for cmdlang")
  (depends
   (ocaml
-   (>= 5.2))
+   (>= 5.4))
   (base
    (>= v0.17))
   (climate
@@ -157,7 +157,7 @@
  (allow_empty)
  (depends
   (ocaml
-   (>= 5.2))
+   (>= 5.4))
   (ocamlformat
    (= 0.28.1))
   (base

--- a/test/cram/doc.t
+++ b/test/cram/doc.t
@@ -187,8 +187,7 @@ help pages.
          dots.
   
   SYNOPSIS
-         ./main_cmdliner.exe doc args-doc-end-with-dots [OPTION]… STRING
-         STRING
+         ./main_cmdliner.exe doc args-doc-end-with-dots [OPTION]… STRING STRING
   
   ARGUMENTS
          STRING (required)

--- a/test/cram/named-with-default.t
+++ b/test/cram/named-with-default.t
@@ -262,8 +262,7 @@ functions or parsers generated from modules with utils.
          Named_with_default__create
   
   SYNOPSIS
-         ./main_cmdliner.exe named with-default create [--who=(A|B)]
-         [OPTION]…
+         ./main_cmdliner.exe named with-default create [--who=(A|B)] [OPTION]…
   
   OPTIONS
          --who=(A|B) (absent=A)
@@ -414,8 +413,7 @@ Named-with-default with a validated string parameter.
          Named_with_default__validated
   
   SYNOPSIS
-         ./main_cmdliner.exe named with-default validated [--who=VAL]
-         [OPTION]…
+         ./main_cmdliner.exe named with-default validated [--who=VAL] [OPTION]…
   
   OPTIONS
          --who=VAL (absent=0000)


### PR DESCRIPTION
- Migrate to OCaml 5.4
- Add CI for 5.4, keep 5.3 and existing versions in CI for now.
- Acknowledge some small formatting changes in cmdliner (still < 2.0).
- Upgrade to cmdliner 2.0.0 is left as future work.